### PR TITLE
Import fastestsmallesttextencoderdecoder only for react-native/expo

### DIFF
--- a/src/drivers/expo-sqlite/index.ts
+++ b/src/drivers/expo-sqlite/index.ts
@@ -17,6 +17,9 @@ import { DatabaseAdapter } from './adapter'
 import { Database, ElectricDatabase, ElectricWebSQLDatabase, ElectrifiedDatabase } from './database'
 import { WebSocketReactNative } from '../../sockets/react-native'
 
+// Provide implementation for TextEncoder/TextDecoder
+import 'fastestsmallesttextencoderdecoder'
+
 export { DatabaseAdapter, ElectricDatabase, ElectricWebSQLDatabase }
 export type { Database, ElectrifiedDatabase }
 

--- a/src/drivers/react-native-sqlite-storage/index.ts
+++ b/src/drivers/react-native-sqlite-storage/index.ts
@@ -17,6 +17,9 @@ import { DatabaseAdapter } from './adapter'
 import { Database, ElectricDatabase, ElectrifiedDatabase } from './database'
 import { WebSocketReactNative } from '../../sockets/react-native'
 
+// Provide implementation for TextEncoder/TextDecoder
+import 'fastestsmallesttextencoderdecoder'
+
 export { DatabaseAdapter, ElectricDatabase }
 export type { Database, ElectrifiedDatabase }
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -1,6 +1,4 @@
 import BASE64 from 'base-64'
-import 'fastestsmallesttextencoderdecoder'
-
 
 export const typeDecoder = {
     number: bytesToNumber,


### PR DESCRIPTION
Moved the import of this dependency into react-native/expo indexes, so that it is not loaded when not necessary