### PR TITLE
[VAX-388] Use FIRST_LSN option for cases where we do not know starting LSN position

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "dependencies": {
     "base-64": "^1.0.0",
     "events": "^3.3.0",
+    "exponential-backoff": "^3.1.0",
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "frame-stream": "^3.0.1",
     "lodash.throttle": "^4.1.1",

--- a/proto/satellite.proto
+++ b/proto/satellite.proto
@@ -85,6 +85,7 @@ message SatInStartReplicationReq {
         // In sync mode consumer of the stream is expected to send SatPingResp
         // message for every committed batch of SatOpLog messages
         SYNC_MODE = 2;
+        FIRST_LSN = 3;
     }
     // LSN position of the log on the producer side
     bytes lsn = 1;

--- a/src/_generated/proto/satellite.ts
+++ b/src/_generated/proto/satellite.ts
@@ -124,6 +124,7 @@ export enum SatInStartReplicationReq_Option {
    * message for every committed batch of SatOpLog messages
    */
   SYNC_MODE = 2,
+  FIRST_LSN = 3,
   UNRECOGNIZED = -1,
 }
 

--- a/src/satellite/client.ts
+++ b/src/satellite/client.ts
@@ -294,6 +294,10 @@ export class SatelliteClient extends EventEmitter implements Client {
       } else {
         this.outbound.ack_lsn = message.lsn;
       }
+      if (!message.options.find(o =>
+        o == SatInStartReplicationReq_Option.FIRST_LSN)) {
+        this.outbound.ack_lsn = DEFAULT_LSN;
+      }
 
       const throttleOpts = { leading: true, trailing: true }
       this.throttledPushTransaction = throttle(() => this.pushTransactions(), this.opts.pushPeriod, throttleOpts)

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -15,7 +15,7 @@ export const base64 = {
     toBytes: (string: string) => Uint8Array.from(BASE64.decode(string), c => c.charCodeAt(0))
 }
 
-export const DEFAULT_LSN = new Uint8Array([48])
+export const DEFAULT_LSN = numberToBytes(0);
 
 export function numberToBytes(i: number) {
     return Uint8Array.of(

--- a/test/support/migrations/1666287419_init/satellite.sql
+++ b/test/support/migrations/1666287419_init/satellite.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS _electric_migrations (
 );
 
 -- Initialisation of the metadata table
-INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA=='), ('clientId', '');
+INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'AAAAAA=='), ('clientId', '');
 
 
 -- These are toggles for turning the triggers on and off

--- a/test/support/migrations/index.js
+++ b/test/support/migrations/index.js
@@ -5,7 +5,7 @@ export const data = {
         "-- The ops log table\nCREATE TABLE IF NOT EXISTS _electric_oplog (\n  rowid INTEGER PRIMARY KEY AUTOINCREMENT,\n  namespace String NOT NULL,\n  tablename String NOT NULL,\n  optype String NOT NULL,\n  primaryKey String NOT NULL,\n  newRow String,\n  oldRow String,\n  timestamp TEXT\n);",
         "-- Somewhere to keep our metadata\nCREATE TABLE IF NOT EXISTS _electric_meta (\n  key TEXT PRIMARY KEY,\n  value BLOB\n);",
         "-- Somewhere to track migrations\nCREATE TABLE IF NOT EXISTS _electric_migrations (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  name TEXT NOT NULL UNIQUE,\n  sha256 TEXT NOT NULL,\n  applied_at TEXT NOT NULL\n);",
-        "-- Initialisation of the metadata table\nINSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA=='), ('clientId', '');",
+        "-- Initialisation of the metadata table\nINSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'AAAAAA=='), ('clientId', '');",
         "-- These are toggles for turning the triggers on and off\nDROP TABLE IF EXISTS _electric_trigger_settings;",
         "CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,6 +1872,11 @@ expand-template@^2.0.3:
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
+exponential-backoff@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.0.tgz#9409c7e579131f8bd4b32d7d8094a911040f2e68"
+  integrity sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA==
+
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"


### PR DESCRIPTION

We treat LSN position of non-Vaxine entity as opaque object, so no hardcoded 0 values for starting position