### PR TITLE
[VAX-460] Extend Auth request with protocol and schema version headers

### DIFF
--- a/proto/satellite.proto
+++ b/proto/satellite.proto
@@ -37,7 +37,7 @@ message SatPingResp{
     optional bytes lsn = 1;
 }
 
-enum AuthHeader {
+enum SatAuthHeader {
     // protobuff required to have this by default
     UNSPECIFIED = 0;
     // required header
@@ -51,8 +51,8 @@ enum AuthHeader {
     SCHEMA_VERSION = 2;
 }
 
-message AuthHeaderPair {
-    AuthHeader key = 1;
+message SatAuthHeaderPair {
+    SatAuthHeader key = 1;
     string value = 2;
 }
 
@@ -68,7 +68,7 @@ message SatAuthReq {
     // Authentification token, auth method specific, required
     string token = 2;
     // Headers, required
-    repeated AuthHeaderPair headers = 3;
+    repeated SatAuthHeaderPair headers = 3;
 }
 
 // (Server) Auth response
@@ -76,7 +76,7 @@ message SatAuthResp {
     // Identity of the Server
     string id = 1;
     // Headers optional
-    repeated AuthHeaderPair headers = 3;
+    repeated SatAuthHeaderPair headers = 3;
 }
 
 // General purpose error message, that could be sent to any request from any
@@ -88,6 +88,8 @@ message SatErrorResp {
         AUTH_FAILED = 2;
         REPLICATION_FAILED = 3;
         INVALID_REQUEST = 4;
+        PROTO_VSN_MISSMATCH = 5;
+        SCHEMA_VSN_MISSMATCH = 6;
     }
 
     ErrorCode error_type = 1;

--- a/proto/satellite.proto
+++ b/proto/satellite.proto
@@ -42,7 +42,7 @@ enum SatAuthHeader {
     UNSPECIFIED = 0;
     // required header
     // protobuf protocol version, this version is picked from
-    // the package statement of this protobuf file, for example "v0.1"
+    // the package statement of this protobuf file, for example "Electric.Satellite.v10_13"
     PROTO_VERSION = 1;
 
     // required header

--- a/proto/satellite.proto
+++ b/proto/satellite.proto
@@ -17,16 +17,13 @@
 // bidirectional replication is enabled. If one of the parties is not involved
 // in the replication lsn field may be left empty.
 syntax = "proto3";
-package Electric.Satellite;
 
-// (Client)
-message SatGetServerInfoReq{}
-
-// (Server)
-message SatGetServerInfoResp {
-    string server_version = 1;
-    string node = 2;
-}
+// NOTE: Part after Electric.Satellite is used as a version of the protocol
+// itseld where the format vMAJOR.MINOR is treated in the following way:
+// MAJOR version when incompatible API changes are introduced
+// MINOR version when functionality or bugfix in a backwards compatible manner
+// are introduced.
+package Electric.Satellite.v0_1;
 
 // Ping request. Can be send by any party
 message SatPingReq{
@@ -40,24 +37,46 @@ message SatPingResp{
     optional bytes lsn = 1;
 }
 
+enum AuthHeader {
+    // protobuff required to have this by default
+    UNSPECIFIED = 0;
+    // required header
+    // protobuf protocol version, this version is picked from
+    // the package statement of this protobuf file, for example "v0.1"
+    PROTO_VERSION = 1;
+
+    // required header
+    // last schema version applied on the client. Is prepended with the hash
+    // algorithm type, for example: "sha256:71c9f..."
+    SCHEMA_VERSION = 2;
+}
+
+message AuthHeaderPair {
+    AuthHeader key = 1;
+    string value = 2;
+}
+
 // (Client) Auth request
 //
 // Client request is the first request that the client should send before
 // executing any other request
 message SatAuthReq {
+
     // Identity of the Satelite application. Is expected to be something like
     // UUID. Required field
     string id = 1;
-    // Authentification token, auth method specific
+    // Authentification token, auth method specific, required
     string token = 2;
-    string schema_version = 3;
-    string schema_hash = 4;
+    // Headers, required
+    repeated AuthHeaderPair headers = 3;
 }
 
 // (Server) Auth response
 message SatAuthResp {
     // Identity of the Server
     string id = 1;
+    // Headers optional
+    repeated AuthHeaderPair headers = 3;
 }
 
 // General purpose error message, that could be sent to any request from any

--- a/src/_generated/proto/satellite.ts
+++ b/src/_generated/proto/satellite.ts
@@ -26,7 +26,7 @@ export const protobufPackage = "Electric.Satellite.v0_1";
  * in the replication lsn field may be left empty.
  */
 
-export enum AuthHeader {
+export enum SatAuthHeader {
   /** UNSPECIFIED - protobuff required to have this by default */
   UNSPECIFIED = 0,
   /**
@@ -60,9 +60,9 @@ export interface SatPingResp {
   lsn?: Uint8Array | undefined;
 }
 
-export interface AuthHeaderPair {
-  $type: "Electric.Satellite.v0_1.AuthHeaderPair";
-  key: AuthHeader;
+export interface SatAuthHeaderPair {
+  $type: "Electric.Satellite.v0_1.SatAuthHeaderPair";
+  key: SatAuthHeader;
   value: string;
 }
 
@@ -82,7 +82,7 @@ export interface SatAuthReq {
   /** Authentification token, auth method specific, required */
   token: string;
   /** Headers, required */
-  headers: AuthHeaderPair[];
+  headers: SatAuthHeaderPair[];
 }
 
 /** (Server) Auth response */
@@ -91,7 +91,7 @@ export interface SatAuthResp {
   /** Identity of the Server */
   id: string;
   /** Headers optional */
-  headers: AuthHeaderPair[];
+  headers: SatAuthHeaderPair[];
 }
 
 /**
@@ -109,6 +109,8 @@ export enum SatErrorResp_ErrorCode {
   AUTH_FAILED = 2,
   REPLICATION_FAILED = 3,
   INVALID_REQUEST = 4,
+  PROTO_VSN_MISSMATCH = 5,
+  SCHEMA_VSN_MISSMATCH = 6,
   UNRECOGNIZED = -1,
 }
 
@@ -362,14 +364,14 @@ export const SatPingResp = {
 
 messageTypeRegistry.set(SatPingResp.$type, SatPingResp);
 
-function createBaseAuthHeaderPair(): AuthHeaderPair {
-  return { $type: "Electric.Satellite.v0_1.AuthHeaderPair", key: 0, value: "" };
+function createBaseSatAuthHeaderPair(): SatAuthHeaderPair {
+  return { $type: "Electric.Satellite.v0_1.SatAuthHeaderPair", key: 0, value: "" };
 }
 
-export const AuthHeaderPair = {
-  $type: "Electric.Satellite.v0_1.AuthHeaderPair" as const,
+export const SatAuthHeaderPair = {
+  $type: "Electric.Satellite.v0_1.SatAuthHeaderPair" as const,
 
-  encode(message: AuthHeaderPair, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+  encode(message: SatAuthHeaderPair, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
     }
@@ -379,10 +381,10 @@ export const AuthHeaderPair = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): AuthHeaderPair {
+  decode(input: _m0.Reader | Uint8Array, length?: number): SatAuthHeaderPair {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseAuthHeaderPair();
+    const message = createBaseSatAuthHeaderPair();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -400,15 +402,15 @@ export const AuthHeaderPair = {
     return message;
   },
 
-  fromPartial<I extends Exact<DeepPartial<AuthHeaderPair>, I>>(object: I): AuthHeaderPair {
-    const message = createBaseAuthHeaderPair();
+  fromPartial<I extends Exact<DeepPartial<SatAuthHeaderPair>, I>>(object: I): SatAuthHeaderPair {
+    const message = createBaseSatAuthHeaderPair();
     message.key = object.key ?? 0;
     message.value = object.value ?? "";
     return message;
   },
 };
 
-messageTypeRegistry.set(AuthHeaderPair.$type, AuthHeaderPair);
+messageTypeRegistry.set(SatAuthHeaderPair.$type, SatAuthHeaderPair);
 
 function createBaseSatAuthReq(): SatAuthReq {
   return { $type: "Electric.Satellite.v0_1.SatAuthReq", id: "", token: "", headers: [] };
@@ -425,7 +427,7 @@ export const SatAuthReq = {
       writer.uint32(18).string(message.token);
     }
     for (const v of message.headers) {
-      AuthHeaderPair.encode(v!, writer.uint32(26).fork()).ldelim();
+      SatAuthHeaderPair.encode(v!, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -444,7 +446,7 @@ export const SatAuthReq = {
           message.token = reader.string();
           break;
         case 3:
-          message.headers.push(AuthHeaderPair.decode(reader, reader.uint32()));
+          message.headers.push(SatAuthHeaderPair.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -458,7 +460,7 @@ export const SatAuthReq = {
     const message = createBaseSatAuthReq();
     message.id = object.id ?? "";
     message.token = object.token ?? "";
-    message.headers = object.headers?.map((e) => AuthHeaderPair.fromPartial(e)) || [];
+    message.headers = object.headers?.map((e) => SatAuthHeaderPair.fromPartial(e)) || [];
     return message;
   },
 };
@@ -477,7 +479,7 @@ export const SatAuthResp = {
       writer.uint32(10).string(message.id);
     }
     for (const v of message.headers) {
-      AuthHeaderPair.encode(v!, writer.uint32(26).fork()).ldelim();
+      SatAuthHeaderPair.encode(v!, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -493,7 +495,7 @@ export const SatAuthResp = {
           message.id = reader.string();
           break;
         case 3:
-          message.headers.push(AuthHeaderPair.decode(reader, reader.uint32()));
+          message.headers.push(SatAuthHeaderPair.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -506,7 +508,7 @@ export const SatAuthResp = {
   fromPartial<I extends Exact<DeepPartial<SatAuthResp>, I>>(object: I): SatAuthResp {
     const message = createBaseSatAuthResp();
     message.id = object.id ?? "";
-    message.headers = object.headers?.map((e) => AuthHeaderPair.fromPartial(e)) || [];
+    message.headers = object.headers?.map((e) => SatAuthHeaderPair.fromPartial(e)) || [];
     return message;
   },
 };

--- a/src/_generated/proto/satellite.ts
+++ b/src/_generated/proto/satellite.ts
@@ -32,7 +32,7 @@ export enum SatAuthHeader {
   /**
    * PROTO_VERSION - required header
    * protobuf protocol version, this version is picked from
-   * the package statement of this protobuf file, for example "v0.1"
+   * the package statement of this protobuf file, for example "Electric.Satellite.v10_13"
    */
   PROTO_VERSION = 1,
   /**

--- a/src/_generated/proto/satellite.ts
+++ b/src/_generated/proto/satellite.ts
@@ -3,7 +3,7 @@ import Long from "long";
 import _m0 from "protobufjs/minimal.js";
 import { messageTypeRegistry } from "../typeRegistry.js";
 
-export const protobufPackage = "Electric.Satellite";
+export const protobufPackage = "Electric.Satellite.v0_1";
 
 /**
  * This file defines protobuf protocol for Satellite <> Electric replication
@@ -26,32 +26,44 @@ export const protobufPackage = "Electric.Satellite";
  * in the replication lsn field may be left empty.
  */
 
-/** (Client) */
-export interface SatGetServerInfoReq {
-  $type: "Electric.Satellite.SatGetServerInfoReq";
-}
-
-/** (Server) */
-export interface SatGetServerInfoResp {
-  $type: "Electric.Satellite.SatGetServerInfoResp";
-  serverVersion: string;
-  node: string;
+export enum AuthHeader {
+  /** UNSPECIFIED - protobuff required to have this by default */
+  UNSPECIFIED = 0,
+  /**
+   * PROTO_VERSION - required header
+   * protobuf protocol version, this version is picked from
+   * the package statement of this protobuf file, for example "v0.1"
+   */
+  PROTO_VERSION = 1,
+  /**
+   * SCHEMA_VERSION - required header
+   * last schema version applied on the client. Is prepended with the hash
+   * algorithm type, for example: "sha256:71c9f..."
+   */
+  SCHEMA_VERSION = 2,
+  UNRECOGNIZED = -1,
 }
 
 /** Ping request. Can be send by any party */
 export interface SatPingReq {
-  $type: "Electric.Satellite.SatPingReq";
+  $type: "Electric.Satellite.v0_1.SatPingReq";
 }
 
 /** Ping response. */
 export interface SatPingResp {
-  $type: "Electric.Satellite.SatPingResp";
+  $type: "Electric.Satellite.v0_1.SatPingResp";
   /**
    * If LSN is present, it conveys to producer the latest LSN position that
    * was applied on the consumer side. If there is no active replication
    * ongoing the field should be left 0
    */
   lsn?: Uint8Array | undefined;
+}
+
+export interface AuthHeaderPair {
+  $type: "Electric.Satellite.v0_1.AuthHeaderPair";
+  key: AuthHeader;
+  value: string;
 }
 
 /**
@@ -61,23 +73,25 @@ export interface SatPingResp {
  * executing any other request
  */
 export interface SatAuthReq {
-  $type: "Electric.Satellite.SatAuthReq";
+  $type: "Electric.Satellite.v0_1.SatAuthReq";
   /**
    * Identity of the Satelite application. Is expected to be something like
    * UUID. Required field
    */
   id: string;
-  /** Authentification token, auth method specific */
+  /** Authentification token, auth method specific, required */
   token: string;
-  schemaVersion: string;
-  schemaHash: string;
+  /** Headers, required */
+  headers: AuthHeaderPair[];
 }
 
 /** (Server) Auth response */
 export interface SatAuthResp {
-  $type: "Electric.Satellite.SatAuthResp";
+  $type: "Electric.Satellite.v0_1.SatAuthResp";
   /** Identity of the Server */
   id: string;
+  /** Headers optional */
+  headers: AuthHeaderPair[];
 }
 
 /**
@@ -85,7 +99,7 @@ export interface SatAuthResp {
  * sides. FIXME: We might want to separate that into Client/Server parts
  */
 export interface SatErrorResp {
-  $type: "Electric.Satellite.SatErrorResp";
+  $type: "Electric.Satellite.v0_1.SatErrorResp";
   errorType: SatErrorResp_ErrorCode;
 }
 
@@ -100,7 +114,7 @@ export enum SatErrorResp_ErrorCode {
 
 /** (Consumer) Starts replication stream from producer to consumer */
 export interface SatInStartReplicationReq {
-  $type: "Electric.Satellite.SatInStartReplicationReq";
+  $type: "Electric.Satellite.v0_1.SatInStartReplicationReq";
   /** LSN position of the log on the producer side */
   lsn: Uint8Array;
   options: SatInStartReplicationReq_Option[];
@@ -130,27 +144,27 @@ export enum SatInStartReplicationReq_Option {
 
 /** (Producer) Acknowledgement that replication have been started */
 export interface SatInStartReplicationResp {
-  $type: "Electric.Satellite.SatInStartReplicationResp";
+  $type: "Electric.Satellite.v0_1.SatInStartReplicationResp";
 }
 
 /** (Consumer) Request to stop replication */
 export interface SatInStopReplicationReq {
-  $type: "Electric.Satellite.SatInStopReplicationReq";
+  $type: "Electric.Satellite.v0_1.SatInStopReplicationReq";
 }
 
 /** (Producer) Acknowledgement that repliation have been stopped */
 export interface SatInStopReplicationResp {
-  $type: "Electric.Satellite.SatInStopReplicationResp";
+  $type: "Electric.Satellite.v0_1.SatInStopReplicationResp";
 }
 
 export interface SatRelationColumn {
-  $type: "Electric.Satellite.SatRelationColumn";
+  $type: "Electric.Satellite.v0_1.SatRelationColumn";
   name: string;
   type: string;
 }
 
 export interface SatRelation {
-  $type: "Electric.Satellite.SatRelation";
+  $type: "Electric.Satellite.v0_1.SatRelation";
   schemaName: string;
   tableType: SatRelation_RelationType;
   tableName: string;
@@ -178,7 +192,7 @@ export enum SatRelation_RelationType {
  * transaction boundaries.
  */
 export interface SatOpLog {
-  $type: "Electric.Satellite.SatOpLog";
+  $type: "Electric.Satellite.v0_1.SatOpLog";
   ops: SatTransOp[];
 }
 
@@ -187,7 +201,7 @@ export interface SatOpLog {
  * message
  */
 export interface SatTransOp {
-  $type: "Electric.Satellite.SatTransOp";
+  $type: "Electric.Satellite.v0_1.SatTransOp";
   begin: SatOpBegin | undefined;
   commit: SatOpCommit | undefined;
   update: SatOpUpdate | undefined;
@@ -200,7 +214,7 @@ export interface SatTransOp {
  * should be only send as payload in the SatTransOp message
  */
 export interface SatOpBegin {
-  $type: "Electric.Satellite.SatOpBegin";
+  $type: "Electric.Satellite.v0_1.SatOpBegin";
   commitTimestamp: Long;
   transId: string;
   lsn: Uint8Array;
@@ -211,7 +225,7 @@ export interface SatOpBegin {
  * should be only send as payload in the SatTransOp message
  */
 export interface SatOpCommit {
-  $type: "Electric.Satellite.SatOpCommit";
+  $type: "Electric.Satellite.v0_1.SatOpCommit";
   commitTimestamp: Long;
   transId: string;
   lsn: Uint8Array;
@@ -222,7 +236,7 @@ export interface SatOpCommit {
  * SatTransOp message
  */
 export interface SatOpInsert {
-  $type: "Electric.Satellite.SatOpInsert";
+  $type: "Electric.Satellite.v0_1.SatOpInsert";
   relationId: number;
   rowData: SatOpRow | undefined;
 }
@@ -232,7 +246,7 @@ export interface SatOpInsert {
  * SatTransOp message
  */
 export interface SatOpUpdate {
-  $type: "Electric.Satellite.SatOpUpdate";
+  $type: "Electric.Satellite.v0_1.SatOpUpdate";
   relationId: number;
   rowData: SatOpRow | undefined;
   oldRowData: SatOpRow | undefined;
@@ -243,7 +257,7 @@ export interface SatOpUpdate {
  * SatTransOp message
  */
 export interface SatOpDelete {
-  $type: "Electric.Satellite.SatOpDelete";
+  $type: "Electric.Satellite.v0_1.SatOpDelete";
   relationId: number;
   oldRowData: SatOpRow | undefined;
 }
@@ -254,7 +268,7 @@ export interface SatOpDelete {
  * stream if it's ongoing.
  */
 export interface SatMigrationNotification {
-  $type: "Electric.Satellite.SatMigrationNotification";
+  $type: "Electric.Satellite.v0_1.SatMigrationNotification";
   /** all fields are required */
   oldSchemaVersion: string;
   oldSchemaHash: string;
@@ -264,7 +278,7 @@ export interface SatMigrationNotification {
 
 /** Message that corresponds to the single row. */
 export interface SatOpRow {
-  $type: "Electric.Satellite.SatOpRow";
+  $type: "Electric.Satellite.v0_1.SatOpRow";
   nullsBitmask: Uint8Array;
   /**
    * values may contain binaries with size 0 for NULLs and empty values
@@ -273,94 +287,12 @@ export interface SatOpRow {
   values: Uint8Array[];
 }
 
-function createBaseSatGetServerInfoReq(): SatGetServerInfoReq {
-  return { $type: "Electric.Satellite.SatGetServerInfoReq" };
-}
-
-export const SatGetServerInfoReq = {
-  $type: "Electric.Satellite.SatGetServerInfoReq" as const,
-
-  encode(_: SatGetServerInfoReq, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): SatGetServerInfoReq {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSatGetServerInfoReq();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<SatGetServerInfoReq>, I>>(_: I): SatGetServerInfoReq {
-    const message = createBaseSatGetServerInfoReq();
-    return message;
-  },
-};
-
-messageTypeRegistry.set(SatGetServerInfoReq.$type, SatGetServerInfoReq);
-
-function createBaseSatGetServerInfoResp(): SatGetServerInfoResp {
-  return { $type: "Electric.Satellite.SatGetServerInfoResp", serverVersion: "", node: "" };
-}
-
-export const SatGetServerInfoResp = {
-  $type: "Electric.Satellite.SatGetServerInfoResp" as const,
-
-  encode(message: SatGetServerInfoResp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.serverVersion !== "") {
-      writer.uint32(10).string(message.serverVersion);
-    }
-    if (message.node !== "") {
-      writer.uint32(18).string(message.node);
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): SatGetServerInfoResp {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSatGetServerInfoResp();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.serverVersion = reader.string();
-          break;
-        case 2:
-          message.node = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<SatGetServerInfoResp>, I>>(object: I): SatGetServerInfoResp {
-    const message = createBaseSatGetServerInfoResp();
-    message.serverVersion = object.serverVersion ?? "";
-    message.node = object.node ?? "";
-    return message;
-  },
-};
-
-messageTypeRegistry.set(SatGetServerInfoResp.$type, SatGetServerInfoResp);
-
 function createBaseSatPingReq(): SatPingReq {
-  return { $type: "Electric.Satellite.SatPingReq" };
+  return { $type: "Electric.Satellite.v0_1.SatPingReq" };
 }
 
 export const SatPingReq = {
-  $type: "Electric.Satellite.SatPingReq" as const,
+  $type: "Electric.Satellite.v0_1.SatPingReq" as const,
 
   encode(_: SatPingReq, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     return writer;
@@ -390,11 +322,11 @@ export const SatPingReq = {
 messageTypeRegistry.set(SatPingReq.$type, SatPingReq);
 
 function createBaseSatPingResp(): SatPingResp {
-  return { $type: "Electric.Satellite.SatPingResp", lsn: undefined };
+  return { $type: "Electric.Satellite.v0_1.SatPingResp", lsn: undefined };
 }
 
 export const SatPingResp = {
-  $type: "Electric.Satellite.SatPingResp" as const,
+  $type: "Electric.Satellite.v0_1.SatPingResp" as const,
 
   encode(message: SatPingResp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.lsn !== undefined) {
@@ -430,12 +362,60 @@ export const SatPingResp = {
 
 messageTypeRegistry.set(SatPingResp.$type, SatPingResp);
 
+function createBaseAuthHeaderPair(): AuthHeaderPair {
+  return { $type: "Electric.Satellite.v0_1.AuthHeaderPair", key: 0, value: "" };
+}
+
+export const AuthHeaderPair = {
+  $type: "Electric.Satellite.v0_1.AuthHeaderPair" as const,
+
+  encode(message: AuthHeaderPair, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.key !== 0) {
+      writer.uint32(8).int32(message.key);
+    }
+    if (message.value !== "") {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): AuthHeaderPair {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAuthHeaderPair();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.int32() as any;
+          break;
+        case 2:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AuthHeaderPair>, I>>(object: I): AuthHeaderPair {
+    const message = createBaseAuthHeaderPair();
+    message.key = object.key ?? 0;
+    message.value = object.value ?? "";
+    return message;
+  },
+};
+
+messageTypeRegistry.set(AuthHeaderPair.$type, AuthHeaderPair);
+
 function createBaseSatAuthReq(): SatAuthReq {
-  return { $type: "Electric.Satellite.SatAuthReq", id: "", token: "", schemaVersion: "", schemaHash: "" };
+  return { $type: "Electric.Satellite.v0_1.SatAuthReq", id: "", token: "", headers: [] };
 }
 
 export const SatAuthReq = {
-  $type: "Electric.Satellite.SatAuthReq" as const,
+  $type: "Electric.Satellite.v0_1.SatAuthReq" as const,
 
   encode(message: SatAuthReq, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.id !== "") {
@@ -444,11 +424,8 @@ export const SatAuthReq = {
     if (message.token !== "") {
       writer.uint32(18).string(message.token);
     }
-    if (message.schemaVersion !== "") {
-      writer.uint32(26).string(message.schemaVersion);
-    }
-    if (message.schemaHash !== "") {
-      writer.uint32(34).string(message.schemaHash);
+    for (const v of message.headers) {
+      AuthHeaderPair.encode(v!, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -467,10 +444,7 @@ export const SatAuthReq = {
           message.token = reader.string();
           break;
         case 3:
-          message.schemaVersion = reader.string();
-          break;
-        case 4:
-          message.schemaHash = reader.string();
+          message.headers.push(AuthHeaderPair.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -484,8 +458,7 @@ export const SatAuthReq = {
     const message = createBaseSatAuthReq();
     message.id = object.id ?? "";
     message.token = object.token ?? "";
-    message.schemaVersion = object.schemaVersion ?? "";
-    message.schemaHash = object.schemaHash ?? "";
+    message.headers = object.headers?.map((e) => AuthHeaderPair.fromPartial(e)) || [];
     return message;
   },
 };
@@ -493,15 +466,18 @@ export const SatAuthReq = {
 messageTypeRegistry.set(SatAuthReq.$type, SatAuthReq);
 
 function createBaseSatAuthResp(): SatAuthResp {
-  return { $type: "Electric.Satellite.SatAuthResp", id: "" };
+  return { $type: "Electric.Satellite.v0_1.SatAuthResp", id: "", headers: [] };
 }
 
 export const SatAuthResp = {
-  $type: "Electric.Satellite.SatAuthResp" as const,
+  $type: "Electric.Satellite.v0_1.SatAuthResp" as const,
 
   encode(message: SatAuthResp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
+    }
+    for (const v of message.headers) {
+      AuthHeaderPair.encode(v!, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -516,6 +492,9 @@ export const SatAuthResp = {
         case 1:
           message.id = reader.string();
           break;
+        case 3:
+          message.headers.push(AuthHeaderPair.decode(reader, reader.uint32()));
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -527,6 +506,7 @@ export const SatAuthResp = {
   fromPartial<I extends Exact<DeepPartial<SatAuthResp>, I>>(object: I): SatAuthResp {
     const message = createBaseSatAuthResp();
     message.id = object.id ?? "";
+    message.headers = object.headers?.map((e) => AuthHeaderPair.fromPartial(e)) || [];
     return message;
   },
 };
@@ -534,11 +514,11 @@ export const SatAuthResp = {
 messageTypeRegistry.set(SatAuthResp.$type, SatAuthResp);
 
 function createBaseSatErrorResp(): SatErrorResp {
-  return { $type: "Electric.Satellite.SatErrorResp", errorType: 0 };
+  return { $type: "Electric.Satellite.v0_1.SatErrorResp", errorType: 0 };
 }
 
 export const SatErrorResp = {
-  $type: "Electric.Satellite.SatErrorResp" as const,
+  $type: "Electric.Satellite.v0_1.SatErrorResp" as const,
 
   encode(message: SatErrorResp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.errorType !== 0) {
@@ -575,11 +555,16 @@ export const SatErrorResp = {
 messageTypeRegistry.set(SatErrorResp.$type, SatErrorResp);
 
 function createBaseSatInStartReplicationReq(): SatInStartReplicationReq {
-  return { $type: "Electric.Satellite.SatInStartReplicationReq", lsn: new Uint8Array(), options: [], syncBatchSize: 0 };
+  return {
+    $type: "Electric.Satellite.v0_1.SatInStartReplicationReq",
+    lsn: new Uint8Array(),
+    options: [],
+    syncBatchSize: 0,
+  };
 }
 
 export const SatInStartReplicationReq = {
-  $type: "Electric.Satellite.SatInStartReplicationReq" as const,
+  $type: "Electric.Satellite.v0_1.SatInStartReplicationReq" as const,
 
   encode(message: SatInStartReplicationReq, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.lsn.length !== 0) {
@@ -639,11 +624,11 @@ export const SatInStartReplicationReq = {
 messageTypeRegistry.set(SatInStartReplicationReq.$type, SatInStartReplicationReq);
 
 function createBaseSatInStartReplicationResp(): SatInStartReplicationResp {
-  return { $type: "Electric.Satellite.SatInStartReplicationResp" };
+  return { $type: "Electric.Satellite.v0_1.SatInStartReplicationResp" };
 }
 
 export const SatInStartReplicationResp = {
-  $type: "Electric.Satellite.SatInStartReplicationResp" as const,
+  $type: "Electric.Satellite.v0_1.SatInStartReplicationResp" as const,
 
   encode(_: SatInStartReplicationResp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     return writer;
@@ -673,11 +658,11 @@ export const SatInStartReplicationResp = {
 messageTypeRegistry.set(SatInStartReplicationResp.$type, SatInStartReplicationResp);
 
 function createBaseSatInStopReplicationReq(): SatInStopReplicationReq {
-  return { $type: "Electric.Satellite.SatInStopReplicationReq" };
+  return { $type: "Electric.Satellite.v0_1.SatInStopReplicationReq" };
 }
 
 export const SatInStopReplicationReq = {
-  $type: "Electric.Satellite.SatInStopReplicationReq" as const,
+  $type: "Electric.Satellite.v0_1.SatInStopReplicationReq" as const,
 
   encode(_: SatInStopReplicationReq, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     return writer;
@@ -707,11 +692,11 @@ export const SatInStopReplicationReq = {
 messageTypeRegistry.set(SatInStopReplicationReq.$type, SatInStopReplicationReq);
 
 function createBaseSatInStopReplicationResp(): SatInStopReplicationResp {
-  return { $type: "Electric.Satellite.SatInStopReplicationResp" };
+  return { $type: "Electric.Satellite.v0_1.SatInStopReplicationResp" };
 }
 
 export const SatInStopReplicationResp = {
-  $type: "Electric.Satellite.SatInStopReplicationResp" as const,
+  $type: "Electric.Satellite.v0_1.SatInStopReplicationResp" as const,
 
   encode(_: SatInStopReplicationResp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     return writer;
@@ -741,11 +726,11 @@ export const SatInStopReplicationResp = {
 messageTypeRegistry.set(SatInStopReplicationResp.$type, SatInStopReplicationResp);
 
 function createBaseSatRelationColumn(): SatRelationColumn {
-  return { $type: "Electric.Satellite.SatRelationColumn", name: "", type: "" };
+  return { $type: "Electric.Satellite.v0_1.SatRelationColumn", name: "", type: "" };
 }
 
 export const SatRelationColumn = {
-  $type: "Electric.Satellite.SatRelationColumn" as const,
+  $type: "Electric.Satellite.v0_1.SatRelationColumn" as const,
 
   encode(message: SatRelationColumn, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.name !== "") {
@@ -790,7 +775,7 @@ messageTypeRegistry.set(SatRelationColumn.$type, SatRelationColumn);
 
 function createBaseSatRelation(): SatRelation {
   return {
-    $type: "Electric.Satellite.SatRelation",
+    $type: "Electric.Satellite.v0_1.SatRelation",
     schemaName: "",
     tableType: 0,
     tableName: "",
@@ -800,7 +785,7 @@ function createBaseSatRelation(): SatRelation {
 }
 
 export const SatRelation = {
-  $type: "Electric.Satellite.SatRelation" as const,
+  $type: "Electric.Satellite.v0_1.SatRelation" as const,
 
   encode(message: SatRelation, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.schemaName !== "") {
@@ -865,11 +850,11 @@ export const SatRelation = {
 messageTypeRegistry.set(SatRelation.$type, SatRelation);
 
 function createBaseSatOpLog(): SatOpLog {
-  return { $type: "Electric.Satellite.SatOpLog", ops: [] };
+  return { $type: "Electric.Satellite.v0_1.SatOpLog", ops: [] };
 }
 
 export const SatOpLog = {
-  $type: "Electric.Satellite.SatOpLog" as const,
+  $type: "Electric.Satellite.v0_1.SatOpLog" as const,
 
   encode(message: SatOpLog, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.ops) {
@@ -907,7 +892,7 @@ messageTypeRegistry.set(SatOpLog.$type, SatOpLog);
 
 function createBaseSatTransOp(): SatTransOp {
   return {
-    $type: "Electric.Satellite.SatTransOp",
+    $type: "Electric.Satellite.v0_1.SatTransOp",
     begin: undefined,
     commit: undefined,
     update: undefined,
@@ -917,7 +902,7 @@ function createBaseSatTransOp(): SatTransOp {
 }
 
 export const SatTransOp = {
-  $type: "Electric.Satellite.SatTransOp" as const,
+  $type: "Electric.Satellite.v0_1.SatTransOp" as const,
 
   encode(message: SatTransOp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.begin !== undefined) {
@@ -992,11 +977,16 @@ export const SatTransOp = {
 messageTypeRegistry.set(SatTransOp.$type, SatTransOp);
 
 function createBaseSatOpBegin(): SatOpBegin {
-  return { $type: "Electric.Satellite.SatOpBegin", commitTimestamp: Long.UZERO, transId: "", lsn: new Uint8Array() };
+  return {
+    $type: "Electric.Satellite.v0_1.SatOpBegin",
+    commitTimestamp: Long.UZERO,
+    transId: "",
+    lsn: new Uint8Array(),
+  };
 }
 
 export const SatOpBegin = {
-  $type: "Electric.Satellite.SatOpBegin" as const,
+  $type: "Electric.Satellite.v0_1.SatOpBegin" as const,
 
   encode(message: SatOpBegin, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (!message.commitTimestamp.isZero()) {
@@ -1049,11 +1039,16 @@ export const SatOpBegin = {
 messageTypeRegistry.set(SatOpBegin.$type, SatOpBegin);
 
 function createBaseSatOpCommit(): SatOpCommit {
-  return { $type: "Electric.Satellite.SatOpCommit", commitTimestamp: Long.UZERO, transId: "", lsn: new Uint8Array() };
+  return {
+    $type: "Electric.Satellite.v0_1.SatOpCommit",
+    commitTimestamp: Long.UZERO,
+    transId: "",
+    lsn: new Uint8Array(),
+  };
 }
 
 export const SatOpCommit = {
-  $type: "Electric.Satellite.SatOpCommit" as const,
+  $type: "Electric.Satellite.v0_1.SatOpCommit" as const,
 
   encode(message: SatOpCommit, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (!message.commitTimestamp.isZero()) {
@@ -1106,11 +1101,11 @@ export const SatOpCommit = {
 messageTypeRegistry.set(SatOpCommit.$type, SatOpCommit);
 
 function createBaseSatOpInsert(): SatOpInsert {
-  return { $type: "Electric.Satellite.SatOpInsert", relationId: 0, rowData: undefined };
+  return { $type: "Electric.Satellite.v0_1.SatOpInsert", relationId: 0, rowData: undefined };
 }
 
 export const SatOpInsert = {
-  $type: "Electric.Satellite.SatOpInsert" as const,
+  $type: "Electric.Satellite.v0_1.SatOpInsert" as const,
 
   encode(message: SatOpInsert, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.relationId !== 0) {
@@ -1156,11 +1151,11 @@ export const SatOpInsert = {
 messageTypeRegistry.set(SatOpInsert.$type, SatOpInsert);
 
 function createBaseSatOpUpdate(): SatOpUpdate {
-  return { $type: "Electric.Satellite.SatOpUpdate", relationId: 0, rowData: undefined, oldRowData: undefined };
+  return { $type: "Electric.Satellite.v0_1.SatOpUpdate", relationId: 0, rowData: undefined, oldRowData: undefined };
 }
 
 export const SatOpUpdate = {
-  $type: "Electric.Satellite.SatOpUpdate" as const,
+  $type: "Electric.Satellite.v0_1.SatOpUpdate" as const,
 
   encode(message: SatOpUpdate, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.relationId !== 0) {
@@ -1215,11 +1210,11 @@ export const SatOpUpdate = {
 messageTypeRegistry.set(SatOpUpdate.$type, SatOpUpdate);
 
 function createBaseSatOpDelete(): SatOpDelete {
-  return { $type: "Electric.Satellite.SatOpDelete", relationId: 0, oldRowData: undefined };
+  return { $type: "Electric.Satellite.v0_1.SatOpDelete", relationId: 0, oldRowData: undefined };
 }
 
 export const SatOpDelete = {
-  $type: "Electric.Satellite.SatOpDelete" as const,
+  $type: "Electric.Satellite.v0_1.SatOpDelete" as const,
 
   encode(message: SatOpDelete, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.relationId !== 0) {
@@ -1266,7 +1261,7 @@ messageTypeRegistry.set(SatOpDelete.$type, SatOpDelete);
 
 function createBaseSatMigrationNotification(): SatMigrationNotification {
   return {
-    $type: "Electric.Satellite.SatMigrationNotification",
+    $type: "Electric.Satellite.v0_1.SatMigrationNotification",
     oldSchemaVersion: "",
     oldSchemaHash: "",
     newSchemaVersion: "",
@@ -1275,7 +1270,7 @@ function createBaseSatMigrationNotification(): SatMigrationNotification {
 }
 
 export const SatMigrationNotification = {
-  $type: "Electric.Satellite.SatMigrationNotification" as const,
+  $type: "Electric.Satellite.v0_1.SatMigrationNotification" as const,
 
   encode(message: SatMigrationNotification, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.oldSchemaVersion !== "") {
@@ -1333,11 +1328,11 @@ export const SatMigrationNotification = {
 messageTypeRegistry.set(SatMigrationNotification.$type, SatMigrationNotification);
 
 function createBaseSatOpRow(): SatOpRow {
-  return { $type: "Electric.Satellite.SatOpRow", nullsBitmask: new Uint8Array(), values: [] };
+  return { $type: "Electric.Satellite.v0_1.SatOpRow", nullsBitmask: new Uint8Array(), values: [] };
 }
 
 export const SatOpRow = {
-  $type: "Electric.Satellite.SatOpRow" as const,
+  $type: "Electric.Satellite.v0_1.SatOpRow" as const,
 
   encode(message: SatOpRow, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.nullsBitmask.length !== 0) {

--- a/src/satellite/client.ts
+++ b/src/satellite/client.ts
@@ -16,8 +16,8 @@ import {
   SatPingResp,
   SatRelation,
   SatRelationColumn,
-  AuthHeader,
-  AuthHeaderPair,
+  SatAuthHeader,
+  SatAuthHeaderPair,
 } from '../_generated/proto/satellite';
 import { getObjFromString, getSizeBuf, getTypeFromCode, SatPbMsg,
          getProtocolVersion, getFullTypeName} from '../util/proto';
@@ -185,9 +185,10 @@ export class SatelliteClient extends EventEmitter implements Client {
 
   authenticate(clientId: string): Promise<AuthResponse | SatelliteError> {
     const { token } = this.opts;
-    const headers = [ AuthHeaderPair.fromPartial({ key: AuthHeader.PROTO_VERSION,
-                                                   value: getProtocolVersion()
-                                                 }) ]
+    const headers = [ SatAuthHeaderPair.fromPartial(
+      { key: SatAuthHeader.PROTO_VERSION,
+        value: getProtocolVersion()
+      }) ]
     const request = SatAuthReq.fromPartial({ id: clientId,
                                              token: token,
                                              headers: headers

--- a/src/satellite/client.ts
+++ b/src/satellite/client.ts
@@ -16,8 +16,11 @@ import {
   SatPingResp,
   SatRelation,
   SatRelationColumn,
+  AuthHeader,
+  AuthHeaderPair,
 } from '../_generated/proto/satellite';
-import { getObjFromString, getSizeBuf, getTypeFromCode, SatPbMsg } from '../util/proto';
+import { getObjFromString, getSizeBuf, getTypeFromCode, SatPbMsg,
+         getProtocolVersion, getFullTypeName} from '../util/proto';
 import { Socket, SocketFactory } from '../sockets/index';
 import _m0 from 'protobufjs/minimal.js';
 import { EventEmitter } from 'events';
@@ -47,18 +50,21 @@ export class SatelliteClient extends EventEmitter implements Client {
   private socketHandler?: (any: any) => void;
   private throttledPushTransaction?: () => void;
 
-  private handlerForMessageType: { [k: string]: IncomingHandler } = {
-    "Electric.Satellite.SatAuthResp": { handle: (resp) => this.handleAuthResp(resp), isRpc: true },
-    "Electric.Satellite.SatInStartReplicationResp": { handle: () => this.handleStartResp(), isRpc: true },
-    "Electric.Satellite.SatInStartReplicationReq": { handle: (req) => this.handleStartReq(req), isRpc: false },
-    "Electric.Satellite.SatInStopReplicationReq": { handle: () => this.handleStopReq(), isRpc: false },
-    "Electric.Satellite.SatInStopReplicationResp": { handle: () => this.handleStopResp(), isRpc: true },
-    "Electric.Satellite.SatPingReq": { handle: () => this.handlePingReq(), isRpc: true },
-    "Electric.Satellite.SatPingResp": { handle: (req) => this.handlePingResp(req), isRpc: false },
-    "Electric.Satellite.SatRelation": { handle: (req) => this.handleRelation(req), isRpc: false },
-    "Electric.Satellite.SatOpLog": { handle: (req) => this.handleTransaction(req), isRpc: false },
-    "Electric.Satellite.SatErrorResp": { handle: (error: SatErrorResp) => this.handleError(error), isRpc: false },
-  }
+  private handlerForMessageType: { [k: string]: IncomingHandler } =
+    Object.fromEntries(
+      Object.entries(
+        {
+          "SatAuthResp": { handle: (resp: any) => this.handleAuthResp(resp), isRpc: true },
+          "SatInStartReplicationResp": { handle: () => this.handleStartResp(), isRpc: true },
+          "SatInStartReplicationReq": { handle: (req: any) => this.handleStartReq(req), isRpc: false },
+          "SatInStopReplicationReq": { handle: () => this.handleStopReq(), isRpc: false },
+          "SatInStopReplicationResp": { handle: () => this.handleStopResp(), isRpc: true },
+          "SatPingReq": { handle: () => this.handlePingReq(), isRpc: true },
+          "SatPingResp": { handle: (req: any) => this.handlePingResp(req), isRpc: false },
+          "SatRelation": { handle: (req: any) => this.handleRelation(req), isRpc: false },
+          "SatOpLog": { handle: (req: any) => this.handleTransaction(req), isRpc: false },
+          "SatErrorResp": { handle: (error: SatErrorResp) => this.handleError(error), isRpc: false },
+        }).map( e => [getFullTypeName(e[0]), e[1]] ))
 
   connectionRetryPolicy: Partial<IBackOffOptions> = {
     delayFirstAttempt: false,
@@ -179,7 +185,13 @@ export class SatelliteClient extends EventEmitter implements Client {
 
   authenticate(clientId: string): Promise<AuthResponse | SatelliteError> {
     const { token } = this.opts;
-    const request = SatAuthReq.fromPartial({ id: clientId, token });
+    const headers = [ AuthHeaderPair.fromPartial({ key: AuthHeader.PROTO_VERSION,
+                                                   value: getProtocolVersion()
+                                                 }) ]
+    const request = SatAuthReq.fromPartial({ id: clientId,
+                                             token: token,
+                                             headers: headers
+                                           });
     return this.rpc<AuthResponse>(request);
   }
 
@@ -573,6 +585,7 @@ export class SatelliteClient extends EventEmitter implements Client {
     let waitingFor: NodeJS.Timeout;
     return new Promise<T | SatelliteError>((resolve, reject) => {
       waitingFor = setTimeout(() => {
+        console.log(`${request.$type}`)
         const error = new SatelliteError(SatelliteErrorCode.TIMEOUT, `${request.$type}`);
         return reject(error);
       }, this.opts.timeout);

--- a/src/util/proto.ts
+++ b/src/util/proto.ts
@@ -1,32 +1,39 @@
 import * as Pb from '../_generated/proto/satellite'
 import * as _m0 from 'protobufjs/minimal';
 
-let msgtypemapping: { [k: string]: [number, any] } = {
-    "Electric.Satellite.SatErrorResp": [0, Pb.SatErrorResp],
-    "Electric.Satellite.SatAuthReq": [1, Pb.SatAuthReq],
-    "Electric.Satellite.SatAuthResp": [2, Pb.SatAuthResp],
-    "Electric.Satellite.SatGetServerInfoReq": [3, Pb.SatGetServerInfoReq],
-    "Electric.Satellite.SatGetServerInfoResp": [4, Pb.SatGetServerInfoResp],
-    "Electric.Satellite.SatPingReq": [5, Pb.SatPingReq],
-    "Electric.Satellite.SatPingResp": [6, Pb.SatPingResp],
-    "Electric.Satellite.SatInStartReplicationReq": [7, Pb.SatInStartReplicationReq],
-    "Electric.Satellite.SatInStartReplicationResp": [8, Pb.SatInStartReplicationResp],
-    "Electric.Satellite.SatInStopReplicationReq": [9, Pb.SatInStopReplicationReq],
-    "Electric.Satellite.SatInStopReplicationResp": [10, Pb.SatInStopReplicationResp],
-    "Electric.Satellite.SatOpLog": [11, Pb.SatOpLog],
-    "Electric.Satellite.SatRelation": [12, Pb.SatRelation],
-    "Electric.Satellite.SatMigrationNotification": [13, Pb.SatMigrationNotification]
-};
+// NOTE: This mapping should be kept in sync with Electric message mapping.
+// Take into account that this mapping is dependent on the protobuf
+// protocol version.
+let msgtypetuples: { [k: string]: [number, any] } =
+    {
+        "SatErrorResp": [0, Pb.SatErrorResp],
+        "SatAuthReq": [1, Pb.SatAuthReq],
+        "SatAuthResp": [2, Pb.SatAuthResp],
+        "SatPingReq": [3, Pb.SatPingReq],
+        "SatPingResp": [4, Pb.SatPingResp],
+        "SatInStartReplicationReq": [5, Pb.SatInStartReplicationReq],
+        "SatInStartReplicationResp": [6, Pb.SatInStartReplicationResp],
+        "SatInStopReplicationReq": [7, Pb.SatInStopReplicationReq],
+        "SatInStopReplicationResp": [8, Pb.SatInStopReplicationResp],
+        "SatOpLog": [9, Pb.SatOpLog],
+        "SatRelation": [10, Pb.SatRelation],
+        "SatMigrationNotification": [11, Pb.SatMigrationNotification]
+    }
 
-let codemapping = Object.fromEntries(
-    Object.entries(msgtypemapping).map(e => [e[1][0], e[0]]))
+let msgtypemapping =
+    Object.fromEntries(
+        Object.entries(msgtypetuples).map(
+            e => [ getFullTypeName(e[0]), e[1]] ))
+
+let codemapping =
+    Object.fromEntries(
+        Object.entries(msgtypetuples).map(
+            e => [e[1][0], getFullTypeName(e[0]) ] ))
 
 export type SatPbMsg =
     | Pb.SatErrorResp
     | Pb.SatAuthReq
     | Pb.SatAuthResp
-    | Pb.SatGetServerInfoReq
-    | Pb.SatGetServerInfoResp
     | Pb.SatPingReq
     | Pb.SatPingResp
     | Pb.SatInStartReplicationReq
@@ -70,4 +77,12 @@ export function getSizeBuf(msg_type: SatPbMsg) {
     var buf = new Uint8Array(1)
     buf.set([msgtype], 0);
     return buf
+}
+
+export function getProtocolVersion(): string {
+    return Pb.protobufPackage;
+}
+
+export function getFullTypeName(message: string): string{
+    return getProtocolVersion() + "." + message
 }

--- a/src/util/proto.ts
+++ b/src/util/proto.ts
@@ -1,10 +1,13 @@
 import * as Pb from '../_generated/proto/satellite'
 import * as _m0 from 'protobufjs/minimal';
 
+type GetName<T extends {"$type": string}> = T["$type"] extends `Electric.Satellite.v0_1.${infer K}` ? K : never
+type MappingTuples = {[k in SatPbMsg as GetName<k>]: [number, SatPbMsgObj<k['$type']>]}
+
 // NOTE: This mapping should be kept in sync with Electric message mapping.
 // Take into account that this mapping is dependent on the protobuf
 // protocol version.
-let msgtypetuples: { [k: string]: [number, any] } =
+let msgtypetuples: MappingTuples =
     {
         "SatErrorResp": [0, Pb.SatErrorResp],
         "SatAuthReq": [1, Pb.SatAuthReq],
@@ -44,8 +47,8 @@ export type SatPbMsg =
     | Pb.SatRelation
     | Pb.SatMigrationNotification
 
-export type SatPbMsgObj = {
-    $type: string;
+export type SatPbMsgObj<Type extends string = string> = {
+    $type: Type;
     encode(message: SatPbMsg, writer: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): SatPbMsg;
     fromPartial<I extends Pb.Exact<Pb.DeepPartial<SatPbMsg>, I>>(object: I): SatPbMsg;


### PR DESCRIPTION
Breaking non-compatible change in the protocol:
- dropped unused info messages
- add version into package definition of the proto file
- add auth headers section with required protocol version and schema