### PR TITLE
VAX-449: Typescript client doesn't set expected defaults and constructsts incorrect URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "./node": "./dist/drivers/better-sqlite3/index.js",
     "./react": "./dist/frameworks/react/index.js",
     "./react-native": "./dist/drivers/react-native-sqlite-storage/index.js",
+    "./debug": "./dist/util/debug/index.js",
     ".": "./dist/index.js",
     "./*": "./dist/*/index.js"
   },
@@ -74,6 +75,9 @@
       ],
       "react-native": [
         "./dist/drivers/react-native-sqlite-storage/index.d.ts"
+      ],
+      "debug": [
+        "./dist/util/debug/index.d.ts"
       ]
     }
   },
@@ -109,13 +113,13 @@
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "frame-stream": "^3.0.1",
     "lodash.throttle": "^4.1.1",
+    "loglevel": "^1.8.1",
     "long": "^5.2.0",
     "protobufjs": "^7.1.1",
     "sqlite-parser": "^1.0.1",
     "uuid": "^9.0.0",
     "walkjs": "^3.2.4",
-    "ws": "^8.8.1",
-    "yalc": "^1.0.0-pre.53"
+    "ws": "^8.8.1"
   },
   "devDependencies": {
     "@testing-library/react": "^13.4.0",

--- a/src/drivers/absurd-sql/worker.ts
+++ b/src/drivers/absurd-sql/worker.ts
@@ -14,6 +14,7 @@ import { DatabaseAdapter } from './adapter'
 import { ElectricDatabase } from './database'
 import { WasmLocator } from './locator'
 import { WebSocketWebFactory } from '../../sockets/web'
+import { setDebugLogLevel } from '../../util/debug'
 
 // Avoid garbage collection.
 const refs = []
@@ -40,6 +41,10 @@ export class ElectricWorker extends WorkerServer {
   async open(dbName: DbName, config: ElectricConfig): Promise<boolean> {
     if (this.SQL === undefined) {
       throw new RequestError(400, 'Must init before opening')
+    }
+
+    if (config.debug) {
+      setDebugLogLevel()
     }
 
     const opts = this.opts

--- a/src/drivers/better-sqlite3/index.ts
+++ b/src/drivers/better-sqlite3/index.ts
@@ -9,7 +9,7 @@ import {
 import { BundleMigrator } from '../../migrators/bundle'
 import { EventNotifier } from '../../notifiers/event'
 import { globalRegistry } from '../../satellite/registry'
-import { addDefaultsToElectricConfig, ElectricConfig } from '../../satellite/config'
+import { ElectricConfig } from '../../satellite/config'
 import { WebSocketNodeFactory } from '../../sockets/node'
 import { DbName } from '../../util/types'
 
@@ -31,8 +31,6 @@ export const electrify = async (db: Database, config: ElectricConfig, opts?: Ele
   const namespace = new ElectricNamespace(adapter, notifier)
   const electric = new ElectricDatabase(db, namespace)
 
-  const configWithDefaults = addDefaultsToElectricConfig(config)
-
-  const electrified = await baseElectrify(dbName, db, electric, adapter, migrator, notifier, socketFactory, registry, configWithDefaults)
+  const electrified = await baseElectrify(dbName, db, electric, adapter, migrator, notifier, socketFactory, registry, config)
   return electrified as unknown as ElectrifiedDatabase
 }

--- a/src/drivers/better-sqlite3/index.ts
+++ b/src/drivers/better-sqlite3/index.ts
@@ -9,7 +9,7 @@ import {
 import { BundleMigrator } from '../../migrators/bundle'
 import { EventNotifier } from '../../notifiers/event'
 import { globalRegistry } from '../../satellite/registry'
-import { ElectricConfig } from '../../satellite/config'
+import { addDefaultsToElectricConfig, ElectricConfig } from '../../satellite/config'
 import { WebSocketNodeFactory } from '../../sockets/node'
 import { DbName } from '../../util/types'
 
@@ -31,6 +31,8 @@ export const electrify = async (db: Database, config: ElectricConfig, opts?: Ele
   const namespace = new ElectricNamespace(adapter, notifier)
   const electric = new ElectricDatabase(db, namespace)
 
-  const electrified = await baseElectrify(dbName, db, electric, adapter, migrator, notifier, socketFactory, registry, config)
+  const configWithDefaults = addDefaultsToElectricConfig(config)
+
+  const electrified = await baseElectrify(dbName, db, electric, adapter, migrator, notifier, socketFactory, registry, configWithDefaults)
   return electrified as unknown as ElectrifiedDatabase
 }

--- a/src/drivers/cordova-sqlite-storage/test.ts
+++ b/src/drivers/cordova-sqlite-storage/test.ts
@@ -7,7 +7,6 @@ import { ElectricNamespace, electrify, ElectrifyOptions } from '../../electric/i
 import { MockMigrator } from '../../migrators/mock'
 import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
-import { ElectricConfig } from '../../satellite/config'
 import { MockRegistry } from '../../satellite/mock'
 
 import { DatabaseAdapter } from './adapter'
@@ -17,9 +16,9 @@ import { MockSocketFactory } from '../../sockets/mock'
 
 type RetVal = Promise<[Database, Notifier, ElectrifiedDatabase]>
 
-const testConfig = { app: "app", env: "test", token: "token", replication: { address: "", port: 0 } }
+const testConfig = { app: "app", token: "token" }
 
-export const initTestable = async (dbName: DbName, config: ElectricConfig = testConfig, opts?: ElectrifyOptions): RetVal => {
+export const initTestable = async (dbName: DbName, config = testConfig, opts?: ElectrifyOptions): RetVal => {
   const db = new MockDatabase(dbName)
 
   const adapter = opts?.adapter || new DatabaseAdapter(db)

--- a/src/drivers/expo-sqlite/test.ts
+++ b/src/drivers/expo-sqlite/test.ts
@@ -7,7 +7,6 @@ import { ElectricNamespace, ElectrifyOptions, electrify } from '../../electric/i
 import { MockMigrator } from '../../migrators/mock'
 import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
-import { ElectricConfig } from '../../satellite/config'
 import { MockRegistry } from '../../satellite/mock'
 
 import { DatabaseAdapter } from './adapter'
@@ -16,9 +15,9 @@ import { MockDatabase, MockWebSQLDatabase } from './mock'
 import { MockSocketFactory } from '../../sockets/mock'
 
 type RetVal = Promise<[Database, Notifier, ElectrifiedDatabase]>
-const testConfig = { app: "app", env: "test", token: "token", replication: { address: "", port: 0 } }
+const testConfig = { app: "app", token: "token" }
 
-export const initTestable = async (dbName: DbName, useWebSQLDatabase: boolean = false, config: ElectricConfig = testConfig, opts?: ElectrifyOptions): RetVal => {
+export const initTestable = async (dbName: DbName, useWebSQLDatabase: boolean = false, config = testConfig, opts?: ElectrifyOptions): RetVal => {
   const db = useWebSQLDatabase
     ? new MockWebSQLDatabase(dbName)
     : new MockDatabase(dbName)

--- a/src/drivers/react-native-sqlite-storage/test.ts
+++ b/src/drivers/react-native-sqlite-storage/test.ts
@@ -8,7 +8,6 @@ import { MockMigrator } from '../../migrators/mock'
 import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
 import { MockRegistry } from '../../satellite/mock'
-import { ElectricConfig } from '../../satellite/config'
 
 import { DatabaseAdapter } from './adapter'
 import { Database, ElectricDatabase, ElectrifiedDatabase } from './database'
@@ -17,9 +16,9 @@ import { MockSocketFactory } from '../../sockets/mock'
 
 type RetVal = Promise<[Database, Notifier, ElectrifiedDatabase]>
 
-const testConfig = { app: "app", env: "test", token: "token", replication: { address: "", port: 0 } }
+const testConfig = { app: "app", token: "token" }
 
-export const initTestable = async (dbName: DbName, config: ElectricConfig = testConfig, opts?: ElectrifyOptions): RetVal => {
+export const initTestable = async (dbName: DbName, config = testConfig, opts?: ElectrifyOptions): RetVal => {
   const db = new MockDatabase(dbName)
 
   const adapter = opts?.adapter || new DatabaseAdapter(db)

--- a/src/drivers/sqlite-plugin/adapter.ts
+++ b/src/drivers/sqlite-plugin/adapter.ts
@@ -5,6 +5,7 @@ import { AnyFunction, Row, Statement } from '../../util/types'
 import { SQLitePlugin, SQLitePluginTransaction } from './index'
 import { ensurePromise } from './promise'
 import { ExecutionResult, rowsFromResults } from './results'
+import Log from 'loglevel'
 
 export abstract class SQLitePluginDatabaseAdapter {
   db: SQLitePlugin
@@ -27,7 +28,7 @@ export abstract class SQLitePluginDatabaseAdapter {
       const txFn = (tx: SQLitePluginTransaction) => {
         for (const { sql, args } of statements) {
           const stmtFailure = (err: any) => {
-            console.log('run statement failure', sql, err)
+            Log.info('run statement failure', sql, err)
             reject(err)
           }
           tx.executeSql(sql, args, undefined, stmtFailure)
@@ -39,7 +40,7 @@ export abstract class SQLitePluginDatabaseAdapter {
       }
 
       const failure = (err: any) => {
-        console.log('run tx failure')
+        Log.info('run tx failure')
         reject(err)
       }
 

--- a/src/electric/index.ts
+++ b/src/electric/index.ts
@@ -6,7 +6,7 @@ import { Registry } from '../satellite/index'
 import { SocketFactory } from '../sockets/index'
 import { proxyOriginal } from '../proxy/original'
 import { DbName } from '../util/types'
-import { ElectricConfig } from '../satellite/config'
+import { addDefaultsToElectricConfig, ElectricConfig } from '../satellite/config'
 
 // These are the options that should be provided to the adapter's electrify
 // entrypoint. They are all optional to optionally allow different / mock
@@ -63,7 +63,8 @@ export const electrify = async (
   registry: Registry,
   config: ElectricConfig,
 ): Promise<AnyElectrifiedDatabase> => {
-  await registry.ensureStarted(dbName, adapter, migrator, notifier, socketFactory, config)
+  const configWithDefaults = addDefaultsToElectricConfig(config)
+  await registry.ensureStarted(dbName, adapter, migrator, notifier, socketFactory, configWithDefaults)
 
   return proxyOriginal(db, electric)
 }

--- a/src/frameworks/react/hooks.ts
+++ b/src/frameworks/react/hooks.ts
@@ -144,8 +144,6 @@ export const useElectricQuery = (query: Query, params?: BindParams) => {
         setResultData(successResult(res))
       })
       .catch((err: any) => {
-        console.log('query error', err)
-
         setResultData(errorResult(err))
       })
   }, [electric, changeSubscriptionKey, cacheKey, paramsKey])

--- a/src/notifiers/event.ts
+++ b/src/notifiers/event.ts
@@ -4,6 +4,7 @@ import { AuthState } from '../auth/index'
 import { randomValue } from '../util/random'
 import { QualifiedTablename } from '../util/tablename'
 import { ConnectivityState, DbName } from '../util/types'
+import Log from 'loglevel'
 
 import {
   AuthStateCallback,
@@ -137,7 +138,7 @@ export class EventNotifier implements Notifier {
     dbNames.forEach(emitPotentialChange)
   }
   actuallyChanged(dbName: DbName, changes: Change[]): void {
-    console.log("actually changed notifier")
+    Log.info("actually changed notifier")
     if (!this._hasDbName(dbName)) {
       return
     }

--- a/src/satellite/client.ts
+++ b/src/satellite/client.ts
@@ -26,7 +26,7 @@ import {
 } from '../util/types';
 import { DEFAULT_LSN, typeEncoder, typeDecoder } from '../util/common'
 import { Client } from '.';
-import { SatelliteClientOverrides, SatelliteClientOpts, satelliteClientDefaults } from './config';
+import { SatelliteClientOpts, satelliteClientDefaults } from './config';
 import { backOff, IBackOffOptions } from 'exponential-backoff';
 import { Notifier } from '../notifiers';
 import Log from 'loglevel';
@@ -34,7 +34,7 @@ import Log from 'loglevel';
 type IncomingHandler = { handle: (msg: any) => any | void, isRpc: boolean }
 
 export class SatelliteClient extends EventEmitter implements Client {
-  private opts: SatelliteClientOpts;
+  private opts: Required<SatelliteClientOpts>;
   private dbName: string;
 
   private socketFactory: SocketFactory;
@@ -70,7 +70,7 @@ export class SatelliteClient extends EventEmitter implements Client {
     timeMultiple: 2
   }
 
-  constructor(dbName: string, socketFactory: SocketFactory, notifier: Notifier, opts: SatelliteClientOverrides) {
+  constructor(dbName: string, socketFactory: SocketFactory, notifier: Notifier, opts: SatelliteClientOpts) {
     super();
 
     this.dbName = dbName
@@ -121,8 +121,9 @@ export class SatelliteClient extends EventEmitter implements Client {
         reject(error)
       })
 
-      const { address, port } = this.opts;
-      this.socket.open({ url: `ws://${address}:${port}/ws` })
+      const { host, port, insecure } = this.opts
+      const url = `${insecure ? "ws" : "wss"}://${host}:${port}/ws`
+      this.socket.open({ url })
     })
 
     const retryPolicy = { ...this.connectionRetryPolicy }

--- a/src/satellite/client.ts
+++ b/src/satellite/client.ts
@@ -29,6 +29,7 @@ import { Client } from '.';
 import { SatelliteClientOverrides, SatelliteClientOpts, satelliteClientDefaults } from './config';
 import { backOff, IBackOffOptions } from 'exponential-backoff';
 import { Notifier } from '../notifiers';
+import Log from 'loglevel';
 
 type IncomingHandler = { handle: (msg: any) => any | void, isRpc: boolean }
 
@@ -133,7 +134,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   }
 
   close(): Promise<void> {
-    console.log("closing client")
+    Log.info("closing client")
 
     this.outbound = this.resetReplication(this.outbound.enqueued_lsn, this.outbound.ack_lsn)
     this.inbound = this.resetReplication(this.inbound.enqueued_lsn, this.inbound.ack_lsn)
@@ -160,7 +161,7 @@ export class SatelliteClient extends EventEmitter implements Client {
 
     this.inbound = this.resetReplication(lsn, lsn, ReplicationStatus.STARTING)
 
-    console.log(`starting replication with lsn ${lsn}`)
+    Log.info(`starting replication with lsn ${lsn}`)
 
     const request = SatInStartReplicationReq.fromPartial({ lsn });
     return this.rpc(request);
@@ -335,7 +336,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   }
 
   private handleStartReq(message: SatInStartReplicationReq) {
-    console.log(`received replication request ${JSON.stringify(message)}`)
+    Log.info(`received replication request ${JSON.stringify(message)}`)
     if (this.outbound.isReplicating == ReplicationStatus.STOPPED) {
       const replication = { ...this.outbound }
       if (!message.options.find(o =>
@@ -426,7 +427,7 @@ export class SatelliteClient extends EventEmitter implements Client {
   }
 
   private handlePingReq() {
-    console.log(`respond to ping with last ack ${this.inbound.ack_lsn}`)
+    Log.info(`respond to ping with last ack ${this.inbound.ack_lsn}`)
     const pong = SatPingResp.fromPartial({ lsn: this.inbound.ack_lsn });
     this.sendMessage(pong);
   }

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -78,13 +78,13 @@ export const addDefaultsToElectricConfig = (config: ElectricConfig): ElectricCon
   const port = (config.replication?.port) ?? 443
   const insecure = (config.replication?.insecure) ?? false
 
-  config = {
+  const newConfig = {
     ...electricConfigDefaults,
     ...config
   }
-  config.replication = { ...config.replication, host, port, insecure }
+  newConfig.replication = { ...config.replication, host, port, insecure }
 
-  return config
+  return newConfig
 }
 
 

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -69,6 +69,7 @@ export interface ElectricConfig {
     address: string
     port: number
   }
+  debug?: boolean,
 }
 
 

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -35,18 +35,17 @@ export const satelliteDefaults: SatelliteOpts = {
 }
 
 export const satelliteClientDefaults = {
-  env: "default" as Environment,
+  env: "default",
   timeout: 3000,
   pushPeriod: 500,
   insecure: false
 }
 
-type Environment = "default" | "staging" | "prod" // what names? is it any name?
 const baseDomain = "electric-sql.com"
 
 export interface SatelliteClientOpts {
   app: string
-  env?: Environment
+  env?: string
   token: string
   host: string
   port: number
@@ -59,7 +58,7 @@ export interface SatelliteClientOpts {
 // Config spec
 export interface ElectricConfig {
   app: string
-  env?: Environment
+  env?: string
   token: string
   migrations?: Migration[],
   replication?: {

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -34,42 +34,60 @@ export const satelliteDefaults: SatelliteOpts = {
   minSnapshotWindow: 40
 }
 
+export const satelliteClientDefaults = {
+  env: "default" as Environment,
+  timeout: 3000,
+  pushPeriod: 500,
+  insecure: false
+}
+
+type Environment = "default" | "staging" | "prod" // what names? is it any name?
+const baseDomain = "electric-sql.com"
+
 export interface SatelliteClientOpts {
   app: string
-  env: string
+  env?: Environment
   token: string
+  host: string
   port: number
-  address: string
-  timeout: number
-  pushPeriod: number
-}
-
-export const satelliteClientDefaults = {
-  timeout: 3000,
-  pushPeriod: 500
-}
-
-export interface SatelliteClientOverrides {
-  app: string
-  env: string
-  token: string
-  port: number
-  address: string
   timeout?: number
   pushPeriod?: number
+  insecure?: boolean
 }
+
 
 // Config spec
 export interface ElectricConfig {
   app: string
-  env: string
+  env?: Environment
   token: string
   migrations?: Migration[],
   replication?: {
-    address: string
+    host: string
     port: number
+    insecure: boolean
   }
   debug?: boolean,
+}
+
+const electricConfigDefaults: Partial<ElectricConfig> = {
+  env: "default"
+}
+
+export const addDefaultsToElectricConfig = (config: ElectricConfig) => {
+  const makeHost = () => `${config.env}.${config.app}.${baseDomain}`
+
+  const host = (config.replication?.host) ? config.replication.host : makeHost()
+  const port = (config.replication?.port) ? config.replication.port : 443
+  const insecure = (config.replication?.insecure) ? config.replication.insecure : false
+
+  config = {
+    ...electricConfigDefaults,
+    ...config
+  }
+  config.replication = { ...config.replication, host, port, insecure }
+
+  return config
 }
 
 

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -73,12 +73,10 @@ const electricConfigDefaults: Partial<ElectricConfig> = {
   env: "default"
 }
 
-export const addDefaultsToElectricConfig = (config: ElectricConfig) => {
-  const makeHost = () => `${config.env}.${config.app}.${baseDomain}`
-
-  const host = (config.replication?.host) ? config.replication.host : makeHost()
-  const port = (config.replication?.port) ? config.replication.port : 443
-  const insecure = (config.replication?.insecure) ? config.replication.insecure : false
+export const addDefaultsToElectricConfig = (config: ElectricConfig): ElectricConfig => {
+  const host = (config.replication?.host) ?? `${config.env}.${config.app}.${baseDomain}`
+  const port = (config.replication?.port) ?? 443
+  const insecure = (config.replication?.insecure) ?? false
 
   config = {
     ...electricConfigDefaults,

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -80,7 +80,7 @@ export const validateConfig = (config : any) => {
     return errors
   }
   
-  const { app, env, replication, debug } = config
+  const { app, replication } = config
   
   if(!app){
     errors.push(`please provide an app identifier: ${config}`)
@@ -91,7 +91,7 @@ export const validateConfig = (config : any) => {
     errors.push("Please provide config.replication = {address, port} details to connect to dev infra")
     errors.push("We're still working to make ElectricSQL service live. You can join the wait list: https://console.electric-sql.com/join/waitlist")
   } else{
-    const { address, port, insecure } = replication
+    const { address, port } = replication
 
     if (!address) {
       errors.push(`Please provide config.replication.address`)
@@ -101,14 +101,7 @@ export const validateConfig = (config : any) => {
     }
     if (port && typeof port != 'number') {
       errors.push(`Please provide correct type for config.replication.port`)
-    }
-    if (insecure && env != 'dev') {
-      errors.push(`insecure only valid for dev environment`)
-    }
-  }
-
-  if (debug) {
-    if (env != 'dev') { errors.push(`debug mode only valid for dev environment`) }
+    }    
   }
 
   return errors

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -80,7 +80,7 @@ export const validateConfig = (config : any) => {
     return errors
   }
   
-  const {replication, app} = config
+  const { app, env, replication, debug } = config
   
   if(!app){
     errors.push(`please provide an app identifier: ${config}`)
@@ -91,10 +91,24 @@ export const validateConfig = (config : any) => {
     errors.push("Please provide config.replication = {address, port} details to connect to dev infra")
     errors.push("We're still working to make ElectricSQL service live. You can join the wait list: https://console.electric-sql.com/join/waitlist")
   } else{
-    const {address, port } = replication
-    if(!address) {errors.push(`Please provide config.replication.address`)}
-    if(!port) {errors.push(`Please provide config.replication.port`)}
-    if(port && typeof port != 'number') {errors.push(`Please provide correct type for config.replication.port`)}
+    const { address, port, insecure } = replication
+
+    if (!address) {
+      errors.push(`Please provide config.replication.address`)
+    }
+    if (!port) {
+      errors.push(`Please provide config.replication.port`)
+    }
+    if (port && typeof port != 'number') {
+      errors.push(`Please provide correct type for config.replication.port`)
+    }
+    if (insecure && env != 'dev') {
+      errors.push(`insecure only valid for dev environment`)
+    }
+  }
+
+  if (debug) {
+    if (env != 'dev') { errors.push(`debug mode only valid for dev environment`) }
   }
 
   return errors

--- a/src/satellite/config.ts
+++ b/src/satellite/config.ts
@@ -90,35 +90,32 @@ export const addDefaultsToElectricConfig = (config: ElectricConfig) => {
 }
 
 
-export const validateConfig = (config : any) => {
+export const validateConfig = (config: any) => {
   const errors = []
-  if(!config){
+  if (!config) {
     errors.push(`config not defined: ${config}`)
     return errors
   }
-  
+
   const { app, replication } = config
-  
-  if(!app){
+
+  if (!app) {
     errors.push(`please provide an app identifier: ${config}`)
     return errors
-  }  
-  
-  if(!replication){
-    errors.push("Please provide config.replication = {address, port} details to connect to dev infra")
-    errors.push("We're still working to make ElectricSQL service live. You can join the wait list: https://console.electric-sql.com/join/waitlist")
-  } else{
-    const { address, port } = replication
+  }
 
-    if (!address) {
-      errors.push(`Please provide config.replication.address`)
+  if (replication) {
+    const { host, port } = replication
+
+    if (!host) {
+      errors.push(`Please provide config.replication.host`)
     }
     if (!port) {
       errors.push(`Please provide config.replication.port`)
     }
     if (port && typeof port != 'number') {
       errors.push(`Please provide correct type for config.replication.port`)
-    }    
+    }
   }
 
   return errors

--- a/src/satellite/registry.ts
+++ b/src/satellite/registry.ts
@@ -155,7 +155,7 @@ export class GlobalRegistry extends BaseRegistry {
     migrator: Migrator,
     notifier: Notifier,
     socketFactory: SocketFactory,
-    config: ElectricConfig,
+    config: Required<ElectricConfig>,
     authState?: AuthState,
   ): Promise<Satellite> {
 
@@ -164,17 +164,14 @@ export class GlobalRegistry extends BaseRegistry {
       throw Error(`invalid config: ${foundErrors}`);
     }
 
-    // FIXME: what should these be?
-    const defaultAddress = `${config.app}-${config.env}.electric-sql.com`
-    const defaultPort = 5133
-
     const satelliteClientOpts = {
       ...satelliteClientDefaults,
       app: config.app,
-      env: config.env,
+      environment: config.env,
       token: config.token,
-      address: config.replication?.address || defaultAddress,
-      port: config.replication?.port || defaultPort,
+      host: config.replication.host,
+      port: config.replication.port,
+      insecure: config.replication.insecure
     }
 
     const client = new SatelliteClient(dbName, socketFactory, notifier, satelliteClientOpts)

--- a/src/satellite/registry.ts
+++ b/src/satellite/registry.ts
@@ -5,7 +5,7 @@ import { Notifier } from '../notifiers/index'
 import { DbName } from '../util/types'
 
 import { Satellite, Registry } from './index'
-import { satelliteDefaults, ElectricConfig, satelliteClientDefaults, validateConfig } from './config'
+import { satelliteDefaults, ElectricConfig, satelliteClientDefaults, validateConfig, SatelliteClientOpts } from './config'
 import { SatelliteProcess } from './process'
 import { SocketFactory } from '../sockets'
 import { SatelliteClient } from './client'
@@ -164,10 +164,10 @@ export class GlobalRegistry extends BaseRegistry {
       throw Error(`invalid config: ${foundErrors}`);
     }
 
-    const satelliteClientOpts = {
+    const satelliteClientOpts: SatelliteClientOpts = {
       ...satelliteClientDefaults,
       app: config.app,
-      environment: config.env,
+      env: config.env,
       token: config.token,
       host: config.replication.host,
       port: config.replication.port,

--- a/src/util/debug/index.ts
+++ b/src/util/debug/index.ts
@@ -1,0 +1,21 @@
+import { AnyElectrifiedDatabase } from "../../drivers"
+import { ElectricNamespace } from "../../electric"
+import { Row } from "../types"
+import Log from 'loglevel'
+
+export type DebugContext = {
+    query?: (sql: string) => Promise<Row[]>,
+    electric?: ElectricNamespace
+}
+
+export const setDebugLogLevel = () => {
+    Log.setLevel('TRACE')
+}
+
+export const init = (electrified: AnyElectrifiedDatabase, context: DebugContext) => {
+    context.query = (sql: string) => electrified.electric.adapter.query({ sql })
+    context.electric = electrified.electric
+
+    setDebugLogLevel()
+}
+

--- a/src/util/debug/log.d.ts
+++ b/src/util/debug/log.d.ts
@@ -1,0 +1,3 @@
+import * as log from 'loglevel';
+export as namespace log;
+export = log;

--- a/test/drivers/better-sqlite3.test.ts
+++ b/test/drivers/better-sqlite3.test.ts
@@ -9,10 +9,12 @@ import { MockNotifier } from '../../src/notifiers/mock'
 import { MockRegistry } from '../../src/satellite/mock'
 import { QualifiedTablename } from '../../src/util/tablename'
 
+const config = { app: "fake", token: "fake" }
+
 test('electrify returns an equivalent database client', async t => {
   const original = new Database('test.db')
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {registry: registry})
+  const db = await electrify(original, config, { registry: registry })
 
   const originalKeys = Object.getOwnPropertyNames(original)
   const originalPrototype = Object.getPrototypeOf(original)
@@ -25,7 +27,7 @@ test('electrify returns an equivalent database client', async t => {
 test('electrify does not remove non-patched properties and methods', async t => {
   const original = new Database('test.db')
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {registry: registry})
+  const db = await electrify(original, config, { registry: registry })
 
   t.is(typeof db.pragma, 'function')
 })
@@ -34,7 +36,7 @@ test('the electrified database has `.electric.potentiallyChanged()`', async t =>
   const original = new Database('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -47,7 +49,7 @@ test('exec\'ing a dangerous statement calls potentiallyChanged', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -60,7 +62,7 @@ test('exec\'ing a non dangerous statement doesn\'t call potentiallyChanged', asy
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -73,7 +75,7 @@ test('running a transaction function calls potentiallyChanged', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -87,7 +89,7 @@ test('running a transaction sub function calls potentiallyChanged', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   const a = db.transaction(() => {})
   const b = db.transaction(() => {})
@@ -109,7 +111,7 @@ test('electrify preserves chainability', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -124,7 +126,7 @@ test('running a prepared statement outside of a transaction notifies', async t =
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -138,7 +140,7 @@ test('running a prepared statement *inside* of a transaction does *not* notify',
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -157,7 +159,7 @@ test('iterating a prepared statement works', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 

--- a/test/satellite/client.test.ts
+++ b/test/satellite/client.test.ts
@@ -21,7 +21,7 @@ import { SatelliteWSServerStub } from './server_ws_stub';
 import test from 'ava'
 import Long from 'long';
 import { AckType, ChangeType, SatelliteErrorCode, Transaction, Relation } from '../../src/util/types';
-import { base64, DEFAULT_LSN, bytesToNumber, typeEncoder, numberToBytes } from '../../src/util/common'
+import { base64, DEFAULT_LSN, bytesToNumber, numberToBytes } from '../../src/util/common'
 import { getObjFromString, getTypeFromCode, getTypeFromString, SatPbMsg } from '../../src/util/proto';
 import { OplogEntry, toTransactions } from '../../src/satellite/oplog';
 import { relations } from './common';
@@ -39,11 +39,12 @@ test.beforeEach(t => {
     new WebSocketNodeFactory(),
     new MockNotifier(dbName),
     {
-      appId: "fake_id",
+      app: "fake_id",
       token: "fake_token",
-      address: '127.0.0.1',
+      host: '127.0.0.1',
       port: 30002,
-      timeout: 10000
+      timeout: 10000,
+      insecure: true   
     }
   );
   const clientId = "91eba0c8-28ba-4a86-a6e8-42731c2c6694"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,9 +1408,6 @@
   "resolved" "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz"
   "version" "2.3.1"
 
-"detect-indent@^6.0.0":
-  "version" "6.1.0"
-
 "detect-libc@^1.0.3":
   "integrity" "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
   "resolved" "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz"
@@ -1994,7 +1991,7 @@
   "resolved" "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
   "version" "1.0.0"
 
-"fs-extra@^8.0.1", "fs-extra@^8.1.0":
+"fs-extra@^8.1.0":
   "integrity" "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="
   "resolved" "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz"
   "version" "8.1.0"
@@ -2126,7 +2123,7 @@
   dependencies:
     "is-glob" "^4.0.3"
 
-"glob@^7.0.0", "glob@^7.1.4", "glob@^7.1.6", "glob@^7.2.0":
+"glob@^7.0.0", "glob@^7.2.0":
   "integrity" "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="
   "resolved" "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   "version" "7.2.3"
@@ -2390,12 +2387,7 @@
   "resolved" "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-2.1.0.tgz"
   "version" "2.1.0"
 
-"ignore-walk@^3.0.3":
-  "version" "3.0.4"
-  dependencies:
-    "minimatch" "^3.0.4"
-
-"ignore@^5.0.4", "ignore@^5.2.0":
+"ignore@^5.2.0":
   "integrity" "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
   "resolved" "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   "version" "5.2.0"
@@ -2445,9 +2437,6 @@
   "integrity" "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
   "resolved" "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
   "version" "1.3.8"
-
-"ini@^2.0.0":
-  "version" "2.0.0"
 
 "ini@2.0.0":
   "integrity" "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
@@ -3211,22 +3200,6 @@
   "integrity" "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA=="
   "resolved" "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz"
   "version" "7.2.0"
-
-"npm-bundled@^1.1.1":
-  "version" "1.1.2"
-  dependencies:
-    "npm-normalize-package-bin" "^1.0.1"
-
-"npm-normalize-package-bin@^1.0.1":
-  "version" "1.0.1"
-
-"npm-packlist@^2.1.5":
-  "version" "2.2.2"
-  dependencies:
-    "glob" "^7.1.6"
-    "ignore-walk" "^3.0.3"
-    "npm-bundled" "^1.1.1"
-    "npm-normalize-package-bin" "^1.0.1"
 
 "npm-run-path@^4.0.1":
   "integrity" "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="
@@ -4949,20 +4922,6 @@
   "resolved" "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   "version" "5.0.8"
 
-"yalc@^1.0.0-pre.53":
-  "integrity" "sha512-tpNqBCpTXplnduzw5XC+FF8zNJ9L/UXmvQyyQj7NKrDNavbJtHvzmZplL5ES/RCnjX7JR7W9wz5GVDXVP3dHUQ=="
-  "resolved" "https://registry.npmjs.org/yalc/-/yalc-1.0.0-pre.53.tgz"
-  "version" "1.0.0-pre.53"
-  dependencies:
-    "chalk" "^4.1.0"
-    "detect-indent" "^6.0.0"
-    "fs-extra" "^8.0.1"
-    "glob" "^7.1.4"
-    "ignore" "^5.0.4"
-    "ini" "^2.0.0"
-    "npm-packlist" "^2.1.5"
-    "yargs" "^16.1.1"
-
 "yallist@^3.0.2":
   "integrity" "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
   "resolved" "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
@@ -4991,17 +4950,6 @@
 "yargs@^16.0.0":
   "integrity" "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="
   "resolved" "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
-  "version" "16.2.0"
-  dependencies:
-    "cliui" "^7.0.2"
-    "escalade" "^3.1.1"
-    "get-caller-file" "^2.0.5"
-    "require-directory" "^2.1.1"
-    "string-width" "^4.2.0"
-    "y18n" "^5.0.5"
-    "yargs-parser" "^20.2.2"
-
-"yargs@^16.1.1":
   "version" "16.2.0"
   dependencies:
     "cliui" "^7.0.2"


### PR DESCRIPTION
- 'env' is set to 'default' by default
- bubbled up defaults that were being set on registry
- set default port
- simplified some config typing and restricts values for env
- replaced address with host
- corrects default host builder

Closes VAX-458.

- [ ] bump release and merge patch for Electric  