### PR TITLE
VAX-427, VAX-449, VAX-458: Fix log handling, insecure websocket proto…

### DIFF
--- a/src/drivers/cordova-sqlite-storage/test.ts
+++ b/src/drivers/cordova-sqlite-storage/test.ts
@@ -7,7 +7,6 @@ import { ElectricNamespace, electrify, ElectrifyOptions } from '../../electric/i
 import { MockMigrator } from '../../migrators/mock'
 import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
-import { ElectricConfig } from '../../satellite/config'
 import { MockRegistry } from '../../satellite/mock'
 
 import { DatabaseAdapter } from './adapter'
@@ -17,9 +16,9 @@ import { MockSocketFactory } from '../../sockets/mock'
 
 type RetVal = Promise<[Database, Notifier, ElectrifiedDatabase]>
 
-const testConfig = { app: "app", env: "test", token: "token", replication: { address: "", port: 0 } }
+const testConfig = { app: "app", token: "token" }
 
-export const initTestable = async (dbName: DbName, config: ElectricConfig = testConfig, opts?: ElectrifyOptions): RetVal => {
+export const initTestable = async (dbName: DbName, config = testConfig, opts?: ElectrifyOptions): RetVal => {
   const db = new MockDatabase(dbName)
 
   const adapter = opts?.adapter || new DatabaseAdapter(db)

--- a/src/drivers/expo-sqlite/test.ts
+++ b/src/drivers/expo-sqlite/test.ts
@@ -7,7 +7,6 @@ import { ElectricNamespace, ElectrifyOptions, electrify } from '../../electric/i
 import { MockMigrator } from '../../migrators/mock'
 import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
-import { ElectricConfig } from '../../satellite/config'
 import { MockRegistry } from '../../satellite/mock'
 
 import { DatabaseAdapter } from './adapter'
@@ -16,9 +15,9 @@ import { MockDatabase, MockWebSQLDatabase } from './mock'
 import { MockSocketFactory } from '../../sockets/mock'
 
 type RetVal = Promise<[Database, Notifier, ElectrifiedDatabase]>
-const testConfig = { app: "app", env: "test", token: "token", replication: { address: "", port: 0 } }
+const testConfig = { app: "app", token: "token" }
 
-export const initTestable = async (dbName: DbName, useWebSQLDatabase: boolean = false, config: ElectricConfig = testConfig, opts?: ElectrifyOptions): RetVal => {
+export const initTestable = async (dbName: DbName, useWebSQLDatabase: boolean = false, config = testConfig, opts?: ElectrifyOptions): RetVal => {
   const db = useWebSQLDatabase
     ? new MockWebSQLDatabase(dbName)
     : new MockDatabase(dbName)

--- a/src/drivers/react-native-sqlite-storage/test.ts
+++ b/src/drivers/react-native-sqlite-storage/test.ts
@@ -8,7 +8,6 @@ import { MockMigrator } from '../../migrators/mock'
 import { Notifier } from '../../notifiers/index'
 import { MockNotifier } from '../../notifiers/mock'
 import { MockRegistry } from '../../satellite/mock'
-import { ElectricConfig } from '../../satellite/config'
 
 import { DatabaseAdapter } from './adapter'
 import { Database, ElectricDatabase, ElectrifiedDatabase } from './database'
@@ -17,9 +16,9 @@ import { MockSocketFactory } from '../../sockets/mock'
 
 type RetVal = Promise<[Database, Notifier, ElectrifiedDatabase]>
 
-const testConfig = { app: "app", env: "test", token: "token", replication: { address: "", port: 0 } }
+const testConfig = { app: "app", token: "token" }
 
-export const initTestable = async (dbName: DbName, config: ElectricConfig = testConfig, opts?: ElectrifyOptions): RetVal => {
+export const initTestable = async (dbName: DbName, config = testConfig, opts?: ElectrifyOptions): RetVal => {
   const db = new MockDatabase(dbName)
 
   const adapter = opts?.adapter || new DatabaseAdapter(db)

--- a/src/electric/index.ts
+++ b/src/electric/index.ts
@@ -6,7 +6,7 @@ import { Registry } from '../satellite/index'
 import { SocketFactory } from '../sockets/index'
 import { proxyOriginal } from '../proxy/original'
 import { DbName } from '../util/types'
-import { ElectricConfig } from '../satellite/config'
+import { addDefaultsToElectricConfig, ElectricConfig } from '../satellite/config'
 
 // These are the options that should be provided to the adapter's electrify
 // entrypoint. They are all optional to optionally allow different / mock
@@ -63,7 +63,8 @@ export const electrify = async (
   registry: Registry,
   config: ElectricConfig,
 ): Promise<AnyElectrifiedDatabase> => {
-  await registry.ensureStarted(dbName, adapter, migrator, notifier, socketFactory, config)
+  const configWithDefaults = addDefaultsToElectricConfig(config)
+  await registry.ensureStarted(dbName, adapter, migrator, notifier, socketFactory, configWithDefaults)
 
   return proxyOriginal(db, electric)
 }

--- a/src/satellite/client.ts
+++ b/src/satellite/client.ts
@@ -29,7 +29,7 @@ import {
 } from '../util/types';
 import { DEFAULT_LSN, typeEncoder, typeDecoder } from '../util/common'
 import { Client } from '.';
-import { SatelliteClientOverrides, SatelliteClientOpts, satelliteClientDefaults } from './config';
+import { SatelliteClientOpts, satelliteClientDefaults } from './config';
 import { backOff, IBackOffOptions } from 'exponential-backoff';
 import { Notifier } from '../notifiers';
 import Log from 'loglevel';
@@ -37,7 +37,7 @@ import Log from 'loglevel';
 type IncomingHandler = { handle: (msg: any) => any | void, isRpc: boolean }
 
 export class SatelliteClient extends EventEmitter implements Client {
-  private opts: SatelliteClientOpts;
+  private opts: Required<SatelliteClientOpts>;
   private dbName: string;
 
   private socketFactory: SocketFactory;
@@ -76,7 +76,7 @@ export class SatelliteClient extends EventEmitter implements Client {
     timeMultiple: 2
   }
 
-  constructor(dbName: string, socketFactory: SocketFactory, notifier: Notifier, opts: SatelliteClientOverrides) {
+  constructor(dbName: string, socketFactory: SocketFactory, notifier: Notifier, opts: SatelliteClientOpts) {
     super();
 
     this.dbName = dbName
@@ -127,8 +127,9 @@ export class SatelliteClient extends EventEmitter implements Client {
         reject(error)
       })
 
-      const { address, port } = this.opts;
-      this.socket.open({ url: `ws://${address}:${port}/ws` })
+      const { host, port, insecure } = this.opts
+      const url = `${insecure ? "ws" : "wss"}://${host}:${port}/ws`
+      this.socket.open({ url })
     })
 
     const retryPolicy = { ...this.connectionRetryPolicy }

--- a/src/satellite/registry.ts
+++ b/src/satellite/registry.ts
@@ -5,7 +5,7 @@ import { Notifier } from '../notifiers/index'
 import { DbName } from '../util/types'
 
 import { Satellite, Registry } from './index'
-import { satelliteDefaults, ElectricConfig, satelliteClientDefaults, validateConfig } from './config'
+import { satelliteDefaults, ElectricConfig, satelliteClientDefaults, validateConfig, SatelliteClientOpts } from './config'
 import { SatelliteProcess } from './process'
 import { SocketFactory } from '../sockets'
 import { SatelliteClient } from './client'
@@ -155,7 +155,7 @@ export class GlobalRegistry extends BaseRegistry {
     migrator: Migrator,
     notifier: Notifier,
     socketFactory: SocketFactory,
-    config: ElectricConfig,
+    config: Required<ElectricConfig>,
     authState?: AuthState,
   ): Promise<Satellite> {
 
@@ -164,17 +164,14 @@ export class GlobalRegistry extends BaseRegistry {
       throw Error(`invalid config: ${foundErrors}`);
     }
 
-    // FIXME: what should these be?
-    const defaultAddress = `${config.app}-${config.env}.electric-sql.com`
-    const defaultPort = 5133
-
-    const satelliteClientOpts = {
+    const satelliteClientOpts: SatelliteClientOpts = {
       ...satelliteClientDefaults,
       app: config.app,
       env: config.env,
       token: config.token,
-      address: config.replication?.address || defaultAddress,
-      port: config.replication?.port || defaultPort,
+      host: config.replication.host,
+      port: config.replication.port,
+      insecure: config.replication.insecure
     }
 
     const client = new SatelliteClient(dbName, socketFactory, notifier, satelliteClientOpts)

--- a/test/drivers/better-sqlite3.test.ts
+++ b/test/drivers/better-sqlite3.test.ts
@@ -9,10 +9,12 @@ import { MockNotifier } from '../../src/notifiers/mock'
 import { MockRegistry } from '../../src/satellite/mock'
 import { QualifiedTablename } from '../../src/util/tablename'
 
+const config = { app: "fake", token: "fake" }
+
 test('electrify returns an equivalent database client', async t => {
   const original = new Database('test.db')
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {registry: registry})
+  const db = await electrify(original, config, { registry: registry })
 
   const originalKeys = Object.getOwnPropertyNames(original)
   const originalPrototype = Object.getPrototypeOf(original)
@@ -25,7 +27,7 @@ test('electrify returns an equivalent database client', async t => {
 test('electrify does not remove non-patched properties and methods', async t => {
   const original = new Database('test.db')
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {registry: registry})
+  const db = await electrify(original, config, { registry: registry })
 
   t.is(typeof db.pragma, 'function')
 })
@@ -34,7 +36,7 @@ test('the electrified database has `.electric.potentiallyChanged()`', async t =>
   const original = new Database('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -47,7 +49,7 @@ test('exec\'ing a dangerous statement calls potentiallyChanged', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -60,7 +62,7 @@ test('exec\'ing a non dangerous statement doesn\'t call potentiallyChanged', asy
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -73,7 +75,7 @@ test('running a transaction function calls potentiallyChanged', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -87,7 +89,7 @@ test('running a transaction sub function calls potentiallyChanged', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   const a = db.transaction(() => {})
   const b = db.transaction(() => {})
@@ -109,7 +111,7 @@ test('electrify preserves chainability', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -124,7 +126,7 @@ test('running a prepared statement outside of a transaction notifies', async t =
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -138,7 +140,7 @@ test('running a prepared statement *inside* of a transaction does *not* notify',
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 
@@ -157,7 +159,7 @@ test('iterating a prepared statement works', async t => {
   const original = new MockDatabase('test.db')
   const notifier = new MockNotifier(original.name)
   const registry = new MockRegistry()
-  const db = await electrify(original, {}, {notifier: notifier, registry: registry})
+  const db = await electrify(original, config, { notifier: notifier, registry: registry })
 
   t.is(notifier.notifications.length, 0)
 

--- a/test/satellite/client.test.ts
+++ b/test/satellite/client.test.ts
@@ -21,7 +21,7 @@ import { SatelliteWSServerStub } from './server_ws_stub';
 import test from 'ava'
 import Long from 'long';
 import { AckType, ChangeType, SatelliteErrorCode, Transaction, Relation } from '../../src/util/types';
-import { base64, DEFAULT_LSN, bytesToNumber, typeEncoder, numberToBytes } from '../../src/util/common'
+import { base64, DEFAULT_LSN, bytesToNumber, numberToBytes } from '../../src/util/common'
 import { getObjFromString, getTypeFromCode, getTypeFromString, SatPbMsg } from '../../src/util/proto';
 import { OplogEntry, toTransactions } from '../../src/satellite/oplog';
 import { relations } from './common';
@@ -39,11 +39,12 @@ test.beforeEach(t => {
     new WebSocketNodeFactory(),
     new MockNotifier(dbName),
     {
-      appId: "fake_id",
+      app: "fake_id",
       token: "fake_token",
-      address: '127.0.0.1',
+      host: '127.0.0.1',
       port: 30002,
-      timeout: 10000
+      timeout: 10000,
+      insecure: true   
     }
   );
   const clientId = "91eba0c8-28ba-4a86-a6e8-42731c2c6694"


### PR DESCRIPTION
…col, configuration changes

VAX-427: Handle logs visibility on client
 - Ensure debug mode can only be set for dev environment

VAX-449: Typescript client doesn't set expected defaults and constructs incorrect URLs

 - 'env' is set to 'default' by default
 - bubbled up defaults that were being set on registry
 - set default port
 - simplified some config typing and restricts values for env
 - replaced address with host
 - corrects default host builder

VAX-458: Switch to secure websockets by default, add insecure option to configuration