### PR TITLE
VAX-473: Satellite uses incorrect LSN when starting the replication from scratch

### DIFF
--- a/src/migrators/schema.ts
+++ b/src/migrators/schema.ts
@@ -5,7 +5,7 @@ export const data = {
                 "-- The ops log table\nCREATE TABLE IF NOT EXISTS _electric_oplog (\n  rowid INTEGER PRIMARY KEY AUTOINCREMENT,\n  namespace String NOT NULL,\n  tablename String NOT NULL,\n  optype String NOT NULL,\n  primaryKey String NOT NULL,\n  newRow String,\n  oldRow String,\n  timestamp TEXT\n);",
                 "-- Somewhere to keep our metadata\nCREATE TABLE IF NOT EXISTS _electric_meta (\n  key TEXT,\n  value BLOB\n);",
                 "-- Somewhere to track migrations\nCREATE TABLE IF NOT EXISTS _electric_migrations (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  name TEXT NOT NULL UNIQUE,\n  sha256 TEXT NOT NULL,\n  applied_at TEXT NOT NULL\n);",
-                "-- Initialisation of the metadata table\nINSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'AAAAAA=='), ('clientId', '');",
+                "-- Initialisation of the metadata table\nINSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', ''), ('clientId', '');",
                 "-- These are toggles for turning the triggers on and off\nDROP TABLE IF EXISTS _electric_trigger_settings;",
                 "CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);"
             ],

--- a/src/satellite/index.ts
+++ b/src/satellite/index.ts
@@ -36,13 +36,13 @@ export interface Client {
   close(): Promise<void | SatelliteError>;
   authenticate(clientId: string): Promise<AuthResponse | SatelliteError>;
   isClosed(): boolean;
-  startReplication(lsn: LSN): Promise<void | SatelliteError>;
+  startReplication(lsn?: LSN): Promise<void | SatelliteError>;
   stopReplication(): Promise<void | SatelliteError>;
   subscribeToTransactions(callback: (transaction: Transaction) => Promise<void>): void;
   enqueueTransaction(transaction: Transaction): void | SatelliteError
   subscribeToAck(callback: AckCallback): void;
   unsubscribeToAck(callback: AckCallback): void;
-  resetOutboundLogPositions(sent: LSN, ack: LSN): void;
+  resetOutboundLogPositions(sent?: LSN, ack?: LSN): void;
   getOutboundLogPositions(): { enqueued: LSN, ack: LSN };
   subscribeToOutboundEvent(event: 'started', callback: () => void): void;
   unsubscribeToOutboundEvent(event: 'started', callback: () => void): void;

--- a/src/satellite/mock.ts
+++ b/src/satellite/mock.ts
@@ -10,7 +10,7 @@ import { SatelliteOpts, SatelliteOverrides, satelliteDefaults } from './config'
 import { BaseRegistry } from './registry'
 import { SocketFactory } from '../sockets'
 import { EventEmitter } from 'events'
-import { DEFAULT_LSN } from '../util'
+import { DEFAULT_LOG_POS } from '../util'
 
 export class MockSatelliteProcess implements Satellite {
   dbName: DbName
@@ -60,10 +60,10 @@ export class MockRegistry extends BaseRegistry {
 export class MockSatelliteClient extends EventEmitter implements Client {  
   replicating = false
   closed = true
-  inboundAck: Uint8Array = DEFAULT_LSN
+  inboundAck: Uint8Array = DEFAULT_LOG_POS
 
-  outboundSent: Uint8Array = DEFAULT_LSN
-  outboundAck: Uint8Array = DEFAULT_LSN
+  outboundSent: Uint8Array = DEFAULT_LOG_POS
+  outboundAck: Uint8Array = DEFAULT_LOG_POS
 
   // to clear any pending timeouts
   timeouts: NodeJS.Timeout[] = []

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -15,7 +15,7 @@ export const base64 = {
     toBytes: (string: string) => Uint8Array.from(BASE64.decode(string), c => c.charCodeAt(0))
 }
 
-export const DEFAULT_LSN = numberToBytes(0);
+export const DEFAULT_LOG_POS = numberToBytes(0);
 
 export function numberToBytes(i: number) {
     return Uint8Array.of(

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -68,8 +68,8 @@ export type Replication = {
     authenticated: boolean
     isReplicating: ReplicationStatus
     relations: Map<number, Relation>
-    ack_lsn: LSN
-    enqueued_lsn: LSN
+    ack_lsn?: LSN
+    enqueued_lsn?: LSN
     transactions: Transaction[]
 }
 

--- a/test/satellite/client.test.ts
+++ b/test/satellite/client.test.ts
@@ -21,7 +21,7 @@ import { SatelliteWSServerStub } from './server_ws_stub';
 import test from 'ava'
 import Long from 'long';
 import { AckType, ChangeType, SatelliteErrorCode, Transaction, Relation } from '../../src/util/types';
-import { base64, DEFAULT_LSN, bytesToNumber, numberToBytes } from '../../src/util/common'
+import { base64, bytesToNumber, numberToBytes } from '../../src/util/common'
 import { getObjFromString, getTypeFromCode, getTypeFromString, SatPbMsg } from '../../src/util/proto';
 import { OplogEntry, toTransactions } from '../../src/satellite/oplog';
 import { relations } from './common';
@@ -232,7 +232,7 @@ test.serial('receive transaction over multiple messages', async t => {
   const { client, server } = t.context as Context;
 
   const start = SatInStartReplicationResp.fromPartial({});
-  const begin = SatOpBegin.fromPartial({ lsn: DEFAULT_LSN, commitTimestamp: Long.ZERO });
+  const begin = SatOpBegin.fromPartial({ commitTimestamp: Long.ZERO });
   const commit = SatOpCommit.fromPartial({});
 
   const rel: Relation = {
@@ -326,9 +326,9 @@ test.serial('acknowledge lsn', async t => {
   await new Promise<void>(async (res) => {
     client.on('transaction', (_t: Transaction, ack: any) => {
       const lsn0 = client['inbound'].ack_lsn
-      t.is(lsn0, DEFAULT_LSN);
+      t.is(lsn0, undefined);
       ack();
-      const lsn1 = base64.fromBytes(client['inbound'].ack_lsn)
+      const lsn1 = base64.fromBytes(client['inbound'].ack_lsn!)
       t.is(lsn1, "FAKE");
       res();
     });

--- a/test/satellite/process.test.ts
+++ b/test/satellite/process.test.ts
@@ -21,7 +21,7 @@ import Long from 'long'
 import { ChangeType, ConnectivityState, LSN, SqlValue, Transaction } from '../../src/util/types'
 import { relations } from './common'
 import { Satellite } from '../../src/satellite'
-import { base64, DEFAULT_LSN, numberToBytes } from '../../src/util/common'
+import { DEFAULT_LOG_POS, numberToBytes } from '../../src/util/common'
 
 import { data as testMigrationsData } from '../support/migrations'
 import { EventNotifier } from '../../src/notifiers'
@@ -121,12 +121,11 @@ test('load metadata', async t => {
   await runMigrations()
 
   const meta = await loadSatelliteMetaTable(adapter)
-  // not sure why we need the buffer here, but might be a problem
   t.deepEqual(meta, {
     compensations: 0,
     lastAckdRowId: '0',
     lastSentRowId: '0',
-    lsn: base64.fromBytes(DEFAULT_LSN),
+    lsn: '',
     clientId: ''
   })
 })
@@ -591,7 +590,7 @@ test('get oplogEntries from transaction', async t => {
   const relations = await satellite['_getLocalRelations']()
 
   const transaction: Transaction = {
-    lsn: DEFAULT_LSN,
+    lsn: DEFAULT_LOG_POS,
     commit_timestamp: Long.UZERO,
     changes: [
       {


### PR DESCRIPTION
Sends FIRST_LSN option for initial replication request.

Treats null and empty LSNs as special value to know when to  set option FIRST_LSN Stops using DEFAULT_LSN for inbound replication which was incorrect and confusing.