### PR TITLE
VAX-509: Intermittent test failure

### DIFF
--- a/test/satellite/process.test.ts
+++ b/test/satellite/process.test.ts
@@ -313,7 +313,7 @@ test('take snapshot and merge local wins', async (t) => {
   const { adapter, runMigrations, satellite, tableInfo } = t.context as any
   await runMigrations()
 
-  const incomingTs = new Date().getTime()
+  const incomingTs = new Date().getTime() - 1
   const incomingEntry = generateOplogEntry(
     tableInfo,
     'main',


### PR DESCRIPTION
Test would fail if incomingTs was not stricly smaller than localTs. Timestamp colision is still possible across replicas, and this should be addressed later as paert of VAX-510