### PR TITLE
VAX-482: keys in electric meta tables have to be unique

### DIFF
--- a/src/migrators/schema.ts
+++ b/src/migrators/schema.ts
@@ -1,12 +1,17 @@
+import { satelliteDefaults } from '../satellite/config'
+
+const { metaTable, migrationsTable, oplogTable, triggersTable } =
+  satelliteDefaults
+
 export const data = {
   migrations: [
     {
       satellite_body: [
-        '-- The ops log table\nCREATE TABLE IF NOT EXISTS _electric_oplog (\n  rowid INTEGER PRIMARY KEY AUTOINCREMENT,\n  namespace String NOT NULL,\n  tablename String NOT NULL,\n  optype String NOT NULL,\n  primaryKey String NOT NULL,\n  newRow String,\n  oldRow String,\n  timestamp TEXT\n);',
-        '-- Somewhere to keep our metadata\nCREATE TABLE IF NOT EXISTS _electric_meta (\n  key TEXT,\n  value BLOB\n);',
-        '-- Somewhere to track migrations\nCREATE TABLE IF NOT EXISTS _electric_migrations (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  name TEXT NOT NULL UNIQUE,\n  sha256 TEXT NOT NULL,\n  applied_at TEXT NOT NULL\n);',
-        "-- Initialisation of the metadata table\nINSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', ''), ('clientId', ''), ('token', 'INITIAL_INVALID_TOKEN'), ('refreshToken', '');",
-        '-- These are toggles for turning the triggers on and off\nDROP TABLE IF EXISTS _electric_trigger_settings;',
+        `-- The ops log table\nCREATE TABLE IF NOT EXISTS ${oplogTable} (\n  rowid INTEGER PRIMARY KEY AUTOINCREMENT,\n  namespace String NOT NULL,\n  tablename String NOT NULL,\n  optype String NOT NULL,\n  primaryKey String NOT NULL,\n  newRow String,\n  oldRow String,\n  timestamp TEXT\n);`,
+        `-- Somewhere to keep our metadata\nCREATE TABLE IF NOT EXISTS ${metaTable} (\n  key TEXT PRIMARY KEY,\n  value BLOB\n);`,
+        `-- Somewhere to track migrations\nCREATE TABLE IF NOT EXISTS ${migrationsTable} (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  name TEXT NOT NULL UNIQUE,\n  sha256 TEXT NOT NULL,\n  applied_at TEXT NOT NULL\n);`,
+        `-- Initialisation of the metadata table\nINSERT INTO ${metaTable} (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', ''), ('clientId', ''), ('token', 'INITIAL_INVALID_TOKEN'), ('refreshToken', '');`,
+        `-- These are toggles for turning the triggers on and off\nDROP TABLE IF EXISTS ${triggersTable};`,
         'CREATE TABLE _electric_trigger_settings(tablename STRING PRIMARY KEY, flag INTEGER);',
       ],
       encoding: 'escaped',

--- a/test/migrators/schema.test.ts
+++ b/test/migrators/schema.test.ts
@@ -1,0 +1,58 @@
+import test from 'ava'
+import Database from 'better-sqlite3'
+
+import { rm as removeFile } from 'node:fs/promises'
+import { AnyDatabase } from '../../src/drivers'
+
+import { DatabaseAdapter } from '../../src/drivers/better-sqlite3/adapter'
+import { BundleMigrator } from '../../src/migrators/bundle'
+import { satelliteDefaults } from '../../src/satellite/config'
+
+import { randomValue } from '../../src/util/random'
+
+import { data as testMigrationsData } from '../support/migrations'
+const { migrations } = testMigrationsData
+
+type Context = {
+  dbName: string
+  adapter: DatabaseAdapter
+  db: AnyDatabase
+}
+
+test.beforeEach((t) => {
+  const dbName = `schema-migrations-${randomValue()}.db`
+  const db = new Database(dbName)
+  const adapter = new DatabaseAdapter(db)
+
+  t.context = {
+    adapter,
+    dbName,
+  }
+})
+
+test.afterEach.always(async (t) => {
+  const { dbName } = t.context as Context
+
+  await removeFile(dbName, { force: true })
+  await removeFile(`${dbName}-journal`, { force: true })
+})
+
+test('check schema keys are unique', async (t) => {
+  const { adapter } = t.context as Context
+
+  const migrator = new BundleMigrator(adapter, migrations)
+  await migrator.up()
+
+  await adapter.run({
+    sql: `INSERT INTO ${satelliteDefaults.metaTable}(key, value) values ('key', 'value')`,
+  })
+  try {
+    await adapter.run({
+      sql: `INSERT INTO ${satelliteDefaults.metaTable}(key, value) values ('key', 'value')`,
+    })
+    t.fail()
+  } catch (err) {
+    const castError = err as { code: string }
+    t.is(castError.code, 'SQLITE_CONSTRAINT_PRIMARYKEY')
+  }
+})


### PR DESCRIPTION
Made table column 'key' primary key.
Added test.
Satellite schema uses default table names instead of hard-coded.