### PR TITLE
fix: return `build` script trigger to `prepare` step

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
     "prepublishOnly": "npm run test",
     "lint": "eslint src --fix",
     "check-styleguide": "prettier --check --loglevel warn . && eslint src --quiet",
-    "prepare": "husky install",
-    "prepack": "npm run build"
+    "prepare": "husky install; npm run build"
   },
   "ava": {
     "timeout": "10m",

--- a/package.json
+++ b/package.json
@@ -90,11 +90,12 @@
     "build": "rm -rf ./dist && tsc && tsmodule build",
     "test": "ava",
     "typecheck": "tsc -p tsconfig.tests.json",
-    "posttest": "yarn typecheck",
-    "prepublishOnly": "yarn test && yarn typecheck && yarn build",
+    "posttest": "npm run typecheck",
+    "prepublishOnly": "npm run test",
     "lint": "eslint src --fix",
     "check-styleguide": "prettier --check --loglevel warn . && eslint src --quiet",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prepack": "npm run build"
   },
   "ava": {
     "timeout": "10m",


### PR DESCRIPTION
This is required for our repo to work when installed from a git repository. I've also replaced `yarn` calls with `npm` calls - they are equivalent in this context, however `yarn` might not be present on machines installing our package outside core development team.