### PR TITLE
Fixed `runInTransaction` in absurd sql adapter

### DIFF
--- a/src/drivers/absurd-sql/adapter.ts
+++ b/src/drivers/absurd-sql/adapter.ts
@@ -26,6 +26,7 @@ export class DatabaseAdapter implements DatabaseAdapterInterface {
     } catch (error) {
       await this.db.run('ROLLBACK')
       open = false
+      throw error // rejects the promise with the reason for the rollback
     } finally {
       if (open) {
         await this.db.run('COMMIT')

--- a/src/drivers/absurd-sql/adapter.ts
+++ b/src/drivers/absurd-sql/adapter.ts
@@ -24,7 +24,7 @@ export class DatabaseAdapter implements DatabaseAdapterInterface {
         await this.db.run(stmt.sql, stmt.args)
       }
     } catch (error) {
-      await this.db.run('ABORT')
+      await this.db.run('ROLLBACK')
       open = false
     } finally {
       if (open) {


### PR DESCRIPTION
The adapter for absurd sql was executing an "ABORT" statement when a query failed.
However, "ABORT" does not exist in SQLite, it is called "ROLLBACK".
I fixed this and throw the error such that the promise is rejected with the reason why the transaction was rolled back.