### PR TITLE
fix: notify the absurd-sql worker with the DbName instead of the Notification

### DIFF
--- a/src/notifiers/bridge.ts
+++ b/src/notifiers/bridge.ts
@@ -43,7 +43,7 @@ export class MainThreadBridgeNotifier
       target: 'notify',
     }
 
-    this.workerClient.notify(method, notification)
+    this.workerClient.notify(method, notification.dbName)
 
     return notification
   }


### PR DESCRIPTION
Notify the absurd-sql worker with the `DbName` instead of the `Notification` because the worker will call `_emitPotentialChange` with the argument that we pass to `notify` (cf. `handleCall` function in `WorkerServer`). Since `_emitPotentialChange` expects a `DbName` that argument should be the DB name and not the notification.