### PR TITLE
fix: await satellite to be started in the global registry

### DIFF
--- a/src/satellite/index.ts
+++ b/src/satellite/index.ts
@@ -33,6 +33,10 @@ export interface Registry {
   stopAll(): Promise<void>
 }
 
+export type ConnectionWrapper = {
+  connectionPromise: Promise<void | Error>
+}
+
 // `Satellite` is the main process handling ElectricSQL replication,
 // processing the opslog and notifying when there are data changes.
 export interface Satellite {
@@ -42,7 +46,7 @@ export interface Satellite {
   migrator: Migrator
   notifier: Notifier
 
-  start(authState?: AuthState): Promise<void | Error>
+  start(authState?: AuthState): Promise<ConnectionWrapper>
   stop(): Promise<void>
 }
 

--- a/src/satellite/mock.ts
+++ b/src/satellite/mock.ts
@@ -13,7 +13,7 @@ import {
   Transaction,
 } from '../util/types'
 
-import { Client, ConsoleClient, Satellite } from './index'
+import { Client, ConnectionWrapper, ConsoleClient, Satellite } from './index'
 import {
   SatelliteOpts,
   SatelliteOverrides,
@@ -55,8 +55,11 @@ export class MockSatelliteProcess implements Satellite {
     this.opts = opts
   }
 
-  async start(_authState?: AuthState): Promise<void> {
+  async start(_authState?: AuthState): Promise<ConnectionWrapper> {
     await sleepAsync(50)
+    return {
+      connectionPromise: new Promise((resolve) => resolve()),
+    }
   }
 
   async stop(): Promise<void> {

--- a/src/satellite/process.ts
+++ b/src/satellite/process.ts
@@ -9,7 +9,7 @@ import {
   ConnectivityStateChangeNotification,
   Notifier,
 } from '../notifiers/index'
-import { Client, ConsoleClient } from './index'
+import { Client, ConnectionWrapper, ConsoleClient } from './index'
 import { QualifiedTablename } from '../util/tablename'
 import {
   AckType,
@@ -119,7 +119,7 @@ export class SatelliteProcess implements Satellite {
     this.relations = {}
   }
 
-  async start(authState?: AuthState): Promise<void | Error> {
+  async start(authState?: AuthState): Promise<ConnectionWrapper> {
     await this.migrator.up()
 
     const isVerified = await this._verifyTableStructure()
@@ -182,7 +182,8 @@ export class SatelliteProcess implements Satellite {
       Log.info(`no lsn retrieved from store`)
     }
 
-    return this._connectAndStartReplication()
+    const connectionPromise = this._connectAndStartReplication()
+    return { connectionPromise }
   }
 
   async _setAuthState(authState?: AuthState): Promise<void | Error> {

--- a/src/satellite/registry.ts
+++ b/src/satellite/registry.ts
@@ -234,7 +234,7 @@ export class GlobalRegistry extends BaseRegistry {
       satelliteConfig,
       satelliteDefaults
     )
-    satellite.start(authState)
+    await satellite.start(authState)
 
     return satellite
   }

--- a/test/satellite/process.test.ts
+++ b/test/satellite/process.test.ts
@@ -194,7 +194,8 @@ test('connect saves new token', async (t) => {
   await runMigrations()
 
   const initToken = await satellite._getMeta('token')
-  await satellite.start()
+  const { connectionPromise } = await satellite.start()
+  await connectionPromise // also wait for the connection to be established
   const receivedToken = await satellite._getMeta('token')
 
   t.assert(initToken != receivedToken)


### PR DESCRIPTION
The registry of the typescript client was no waiting for satellite to be started, this caused web applications that use the wa-sqlite driver to execute queries before the actual tables were created by the migrator.