### PR TITLE
fix: don't overwrite wa-sqlite DB on opening

### DIFF
--- a/src/drivers/wa-sqlite/database.ts
+++ b/src/drivers/wa-sqlite/database.ts
@@ -106,7 +106,11 @@ export class ElectricDatabase implements Database {
 
     // Open the DB connection
     // see: https://rhashimoto.github.io/wa-sqlite/docs/interfaces/SQLiteAPI.html#open_v2
-    const db = await sqlite3.open_v2(dbName)
+    const db = await sqlite3.open_v2(
+      dbName,
+      SQLite.SQLITE_OPEN_CREATE | SQLite.SQLITE_OPEN_READWRITE,
+      dbName
+    )
 
     return new ElectricDatabase(sqlite3, db)
   }


### PR DESCRIPTION
Open wa-sqlite DB with `SQLITE_OPEN_CREATE` flag.
Because if we don't provide any flags, wa-sqlite defaults to `SQLITE_CREATE` which overrides the DB if it already exists.